### PR TITLE
fix a typo in select.coffee

### DIFF
--- a/src/select.coffee
+++ b/src/select.coffee
@@ -171,7 +171,7 @@ Ember.Component.extend Ember.Widgets.BodyEventListener,
     else # getter
       valuePath = @get 'optionValuePath'
       selection = @get 'selection'
-      if valuePath then get(selection, valuePath) else selections
+      if valuePath then get(selection, valuePath) else selection
   .property 'selection'
 
   didInsertElement: ->


### PR DESCRIPTION
Tries to return `selections`, which isn't defined, instead of `selection`.

@igorT @ppong @bigsley 
