### PR TITLE
fix 'Uncaught TypeError: undefined is not a function', spacing in coffee...

### DIFF
--- a/src/select.coffee
+++ b/src/select.coffee
@@ -127,7 +127,7 @@ Ember.Component.extend Ember.Widgets.BodyEventListener,
     style: Ember.computed ->
       height = Math.min @get('height'), @get('totalHeight')
       "height: #{height}px"
-    .property('height', 'totalHeight'),
+  .property('height', 'totalHeight'),
 
   # the list of content that is filtered down based on the query entered
   # in the textbox


### PR DESCRIPTION
...script Ember.ListView.extend function
- I was seeing this error `Uncaught TypeError: undefined is not a function`

See the difference in compiled JS:

before

``` javascript
Ember.ListView.extend({
  style: Ember.computed(function() {
    var height;
    height = Math.min(this.get('height'), this.get('totalHeight'));
    return "height: " + height + "px";
  })
}.property('height', 'totalHeight'))
```

after:

``` javascript
Ember.ListView.extend({
  style: Ember.computed(function() {
    var height;
    height = Math.min(this.get('height'), this.get('totalHeight'));
    return "height: " + height + "px";
  })
}).property('height', 'totalHeight')
```
