### PR TITLE
add .bowerrc file pointing to vendor

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "vendor"
+}


### PR DESCRIPTION
In case the user runs `bower install` outside of the grunt task, this ensures that the install runs against `vendor` and not `bower_components`.
