### PR TITLE
Remove unneeded Ember.run around @destroy calls

### DIFF
--- a/src/modal.coffee
+++ b/src/modal.coffee
@@ -132,7 +132,7 @@ Ember.Component.extend Ember.Widgets.StyleBindingsMixin,
       # disabled when we are in testing mode.
       @$().one $.support.transition.end, => Ember.run this, @destroy
     else
-      Ember.run this, @destroy
+      @destroy
 
   _appendBackdrop: ->
     parentLayer = @$().parent()

--- a/src/popover.coffee
+++ b/src/popover.coffee
@@ -57,7 +57,7 @@ Ember.Widgets.BodyEventListener,
         # about auto run being disabled when we are in testing mode.
         Ember.run this, @destroy
     else
-      Ember.run this, @destroy
+      @destroy
 
   ###
   Calculate the offset of the given iframe relative to the top window.


### PR DESCRIPTION
The Ember.run was only meant to surround the transition.end, but doesn't
need to wrap @destroy calls if there is no transition.

@cyril-sf @Dylnuge 
