### PR TITLE
Fix issue with empty optionLabelPath in select component

### DIFF
--- a/src/select.coffee
+++ b/src/select.coffee
@@ -213,6 +213,10 @@ Ember.AddeparMixins.ResizeHandlerMixin,
 
   contentProxy: Ember.computed ->
     optionLabelPath = @get('optionLabelPath')
+    if optionLabelPath is ''
+      observableString = 'content.@each'
+    else
+      observableString = "content.@each.#{optionLabelPath}"
 
     ContentProxy = Ember.ObjectProxy.extend
       _select: null
@@ -225,7 +229,7 @@ Ember.AddeparMixins.ResizeHandlerMixin,
 
         (@get('content') or []).filter (item) ->
           selectComponent.matcher(query, item)
-      .property "content.@each.#{optionLabelPath}", 'query'
+      .property observableString, 'query'
 
       sortedFilteredContent: Ember.computed ->
         _.sortBy @get('filteredContent'), (item) =>


### PR DESCRIPTION
When optionLabelPath is empty, content proxy was previously observing
'content.@each.', which is invalid and prevented things from properly updating.

@igillis 