### PR TITLE
Select component: Add a property which controls the template which is displays the select options

### DIFF
--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -59,6 +59,13 @@ export default Ember.Component.extend(
   tooltipItemViewClass: SelectTooltipOptionView,
   originalItemViewClass: SelectOptionView,
 
+  /**
+   * The name of the partial which contains the list view which is displayed when
+   * the user opens the drop-down.
+   * @type { string }
+  */
+  listViewPartial: 'select-list-view-partial',
+
   // a map of accepted keys to show dropdown when being pressed
   // these are keys to show dropdown when being pressed
   acceptedKeys: Ember.computed(function() {

--- a/app/templates/select-list-view-partial.hbs
+++ b/app/templates/select-list-view-partial.hbs
@@ -1,0 +1,8 @@
+{{view listView
+  tagName="ul"
+  classNames="ember-select-results"
+  heightBinding="dropdownHeight"
+  rowHeightBinding="rowHeight"
+  contentBinding="groupedContent"
+  itemViewClassBinding="itemView"
+}}

--- a/app/templates/select.hbs
+++ b/app/templates/select.hbs
@@ -10,23 +10,14 @@
     {{/if}}
   </a>
 </div>
-
-<div {{bind-attr class=":dropdown-menu :js-dropdown-menu dropdownMenuClass
-  isDropdownMenuPulledRight:pull-right"}}>
+<div {{bind-attr class=":dropdown-menu :js-dropdown-menu dropdownMenuClass isDropdownMenuPulledRight:pull-right"}}>
   {{#unless isSelect}}
     <div class="ember-select-search">
       {{view searchView}}
     </div>
   {{/unless}}
   {{#if showDropdown}}
-    {{view listView
-      tagName="ul"
-      classNames="ember-select-results"
-      heightBinding="dropdownHeight"
-      rowHeightBinding="rowHeight"
-      contentBinding="groupedContent"
-      itemViewClassBinding="itemView"
-    }}
+    {{partial listViewPartial}}
     {{#if isLoading}}
       <span class="ember-select-loading">Loading...</span>
     {{/if}}

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -31,7 +31,12 @@ emptyContentSelector = '.ember-select-empty-content';
 noResultSelector = '.ember-select-no-results';
 
 moduleForComponent('select-component', '[Integration] Select component', {
-  needs: ['template:select', 'template:select-item', 'template:select-item-layout'],
+  needs: [
+    'template:select',
+    'template:select-item',
+    'template:select-item-layout',
+    'template:select-list-view-partial'
+  ],
 
   setup: function() {
     app = startApp();
@@ -400,4 +405,42 @@ test('shouldEnsureVisible controls whether to ensure visibility', function() {
   select.set('highlighted', 'bar');
   equal(spy.callCount, 0, 'ensureVisible is not called if shouldEnsureVisible is false');
   return spy.restore();
+});
+
+test('Specified dropdownMenuClass is used when the dropdown is opened', function(assert) {
+  assert.expect(1);
+
+  var cssClassName = 'test-class';
+  select = this.subject({
+    content: ['dummy data'],
+    dropdownMenuClass: cssClassName
+  });
+  this.append();
+  var selectElement = select.$();
+  openDropdown(selectElement);
+  return andThen(function() {
+    var expectedClass = '.' + cssClassName;
+    return ok(isPresent(expectedClass, selectElement),
+      'The specified dropdownMenuClass is present');
+  });
+});
+
+test('Can specify a custom partial with listViewPartial', function(assert) {
+  assert.expect(1);
+
+  var compiledTemplate = Ember.Handlebars.
+    compile('<div class="dummy-class-for-partial-list"></div>{{partial "select-list-view-partial"}}');
+  this.container.register('template:custom-list-view-partial', compiledTemplate);
+  select = this.subject({
+    content: ['dummy data'],
+    listViewPartial: 'custom-list-view-partial'
+  });
+  this.append();
+  var selectElement = select.$();
+  openDropdown(selectElement);
+  return andThen(function() {
+    var dummyClassInPartialList = '.dummy-class-for-partial-list';
+    return ok(isPresent(dummyClassInPartialList, selectElement),
+      'The specified listViewPartial is rendered');
+  });
 });

--- a/tests/unit/components/select-component-test.js
+++ b/tests/unit/components/select-component-test.js
@@ -49,7 +49,7 @@ test('Test filtered content using array proxy', function(assert) {
   assert.equal(select.get('filteredContent')[1], 'reddit');
 });
 
-test('Test ', function(assert) {
+test('Option group path', function(assert) {
   assert.expect(12);
 
   var data = [


### PR DESCRIPTION
The changes in this PR makes the select more customizable by adding a property which controls the template displayed when the dropdown is opened and we show a list of option. 

One example use-case is to display the list of options together with a description panel. The description panel updates as we hover over a specific option.