### PR TITLE
Fix issue where the select does not always handle a change in the content array properly

### DIFF
--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -274,6 +274,9 @@ export default Ember.Component.extend(
   // Mountain View
   //   Addepar
   //   Google
+  // Need to specify preparedContent as a dependent property to force this property
+  // to recompute when we switch an empty DS.PromiseArray with a new one
+  // @see preparedContent
   groupedContent: Ember.computed(function() {
     var content, groups, path, result;
     path = this.get('optionGroupPath');

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -274,8 +274,9 @@ export default Ember.Component.extend(
   // Mountain View
   //   Addepar
   //   Google
-  // Need to specify preparedContent as a dependent property to force this property
-  // to recompute when we switch an empty DS.PromiseArray with a new one
+  // For an unknown reason, we need to specify preparedContent as well as preparedContent.[] as a dependent properties
+  // to force this property to recompute when we set content to an empty array and then immediately
+  // set it to a non-empty array. This mirrors the dependent property list of preparedContent
   // @see preparedContent
   groupedContent: Ember.computed(function() {
     var content, groups, path, result;

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -293,7 +293,7 @@ export default Ember.Component.extend(
       return result.pushObjects(groups[key]);
     });
     return result;
-  }).property('preparedContent.[]', 'optionGroupPath', 'labels.[]'),
+  }).property('preparedContent', 'preparedContent.[]', 'optionGroupPath', 'labels.[]'),
 
   isLoading: false,
   isLoaded: Ember.computed.not('isLoading'),

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -445,7 +445,7 @@ test('Can specify a custom partial with listViewPartial', function(assert) {
   });
 });
 
-test('Displays options when content is changed to another empty array and then immediately assigned to a content array', function() {
+test('Select handles a change in the content array properly', function() {
   expect(2);
 
   var resultItemSelector = '.ember-select-result-item';
@@ -455,7 +455,6 @@ test('Displays options when content is changed to another empty array and then i
   this.append();
   var selectElement = select.$();
   openDropdown(selectElement);
-  wait();
   andThen(function() {
     ok(isPresent(resultItemSelector, selectElement), 'Content is displayed');
     select.set('content', []);

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -444,3 +444,24 @@ test('Can specify a custom partial with listViewPartial', function(assert) {
       'The specified listViewPartial is rendered');
   });
 });
+
+test('Displays options when content is changed to another empty array and then immediately assigned to a content array', function() {
+  expect(2);
+
+  var resultItemSelector = '.ember-select-result-item';
+  select = this.subject({
+    content: ['test content']
+  });
+  this.append();
+  var selectElement = select.$();
+  openDropdown(selectElement);
+  wait();
+  andThen(function() {
+    ok(isPresent(resultItemSelector, selectElement), 'Content is displayed');
+    select.set('content', []);
+    select.set('content', ['test content']);
+  });
+  return andThen(function() {
+    ok(isPresent(resultItemSelector, selectElement), 'Content is still displayed');
+  });
+});


### PR DESCRIPTION
This is a minor change to the dependent properties of groupedContent so that it mirrors the dependent property list of preparedContent. Specifically that dependent property depends on the `property` as well as `property.[]`

Use case:

The content attribute is set an empty array and then immediately to a non empty array. 

Bug: The select field does not show any content

