### PR TITLE
Select field should scroll to selection when opened

### DIFF
--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -191,7 +191,15 @@ export default Ember.Component.extend(
     dropupMenuTop = dropdownButtonOffset.top - dropdownMenuHeight - dropdownMargin;
     this.set('isDropup', dropupMenuTop > window.scrollY && dropdownMenuBottom > window.innerHeight);
     this.set('isDropdownMenuPulledRight', dropdownButtonOffset.left + dropdownMenuWidth + dropdownMargin > window.innerWidth);
-    return this.$('.js-dropdown-menu').css('visibility', 'visible');
+    this.$('.js-dropdown-menu').css('visibility', 'visible');
+
+    // When the dropdown is opened or re-rendered, scroll to the highlighted option
+    const highlightedIndex = this.get('highlightedIndex');
+    if (highlightedIndex !== -1 && this.get('shouldEnsureVisible')) {
+      Ember.run.schedule('afterRender', () => {
+        this.ensureVisible(highlightedIndex);
+      });
+    }
   }, 'showDropdown'),
   onResizeEnd: function() {
     // We need to put this on the run loop, because the resize event came from

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -163,6 +163,7 @@ export default Ember.Component.extend(
     if ((this.get('_state') || this.get('state')) !== 'inDOM' || this.get('showDropdown') === false) {
       return;
     }
+    const highlightedIndex = this.get('highlightedIndex');
     // Render the dropdown in a hidden state to get the size
     this.$('.js-dropdown-menu').css('visibility', 'hidden');
 
@@ -194,7 +195,6 @@ export default Ember.Component.extend(
     this.$('.js-dropdown-menu').css('visibility', 'visible');
 
     // When the dropdown is opened or re-rendered, scroll to the highlighted option
-    const highlightedIndex = this.get('highlightedIndex');
     if (highlightedIndex !== -1 && this.get('shouldEnsureVisible')) {
       Ember.run.schedule('afterRender', () => this.ensureVisible(highlightedIndex));
     }

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -196,9 +196,7 @@ export default Ember.Component.extend(
     // When the dropdown is opened or re-rendered, scroll to the highlighted option
     const highlightedIndex = this.get('highlightedIndex');
     if (highlightedIndex !== -1 && this.get('shouldEnsureVisible')) {
-      Ember.run.schedule('afterRender', () => {
-        this.ensureVisible(highlightedIndex);
-      });
+      Ember.run.schedule('afterRender', () => this.ensureVisible(highlightedIndex));
     }
   }, 'showDropdown'),
   onResizeEnd: function() {

--- a/tests/helpers/select.js
+++ b/tests/helpers/select.js
@@ -63,3 +63,14 @@ export function findInSelect(element, itemText) {
     return click(item);
   });
 }
+
+/**
+ * Returns the selector for an option in the select dropdown
+ *
+ * @public
+ * @param {string} selection - The text displayed in an option in the select dropdown.
+ * @return {string} the selector for an option in the select dropdown
+ */
+export function getOptionSelector(selection) {
+  return `.ember-select-results .ember-select-result-item:contains(${selection})`;
+}

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -30,6 +30,10 @@ emptyContentSelector = '.ember-select-empty-content';
 
 noResultSelector = '.ember-select-no-results';
 
+function getOptionSelector(selection) {
+  return `.ember-select-results .ember-select-result-item:contains(${selection})`;
+}
+
 moduleForComponent('select-component', '[Integration] Select component', {
   needs: [
     'template:select',
@@ -462,5 +466,49 @@ test('Select handles a change in the content array properly', function() {
   });
   return andThen(function() {
     ok(isPresent(resultItemSelector, selectElement), 'Content is still displayed');
+  });
+});
+
+test('Selected option is scrolled to when dropdown is opened', function(assert) {
+  assert.expect(1);
+
+  const selection = 'z-last-element';
+  select = this.subject({
+    content: ['foo', 'bana$  na', 'bar ca', selection],
+    selection,
+    dropdownHeight: 30
+  });
+  this.append();
+  andThen(() => {
+    select.set('highlighted', selection);
+  });
+  var selectElement = select.$();
+  openDropdown(selectElement);
+  andThen(() => {
+    assert.ok(isPresent(getOptionSelector(selection)),
+     'The last option is displayed');
+  });
+});
+
+test('Selected option is not scrolled to when shouldEnsureVisible is false', function(assert) {
+  assert.expect(2);
+
+  const selection = 'z-last-element';
+  select = this.subject({
+    content: ['foo', 'bana$  na', 'bar ca', selection],
+    selection,
+    shouldEnsureVisible: false,
+    dropdownHeight: 30
+  });
+  this.append();
+  andThen(() => {
+    select.set('highlighted', selection);
+  });
+  var selectElement = select.$();
+  openDropdown(selectElement);
+  andThen(() => {
+    assert.ok(isPresent('.dropdown-menu'),  'Dropdown menu is displayed');
+    assert.ok(isNotPresent(getOptionSelector(selection)),
+     'The last option is not displayed');
   });
 });

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -17,7 +17,8 @@ import {
 } from '../helpers/keyboard';
 
 import {
-  openDropdown
+  openDropdown,
+  getOptionSelector
 } from '../helpers/select';
 
 
@@ -29,10 +30,6 @@ var emptyContentSelector, noResultSelector, select;
 emptyContentSelector = '.ember-select-empty-content';
 
 noResultSelector = '.ember-select-no-results';
-
-function getOptionSelector(selection) {
-  return `.ember-select-results .ember-select-result-item:contains(${selection})`;
-}
 
 moduleForComponent('select-component', '[Integration] Select component', {
   needs: [
@@ -469,31 +466,32 @@ test('Select handles a change in the content array properly', function() {
   });
 });
 
-test('Selected option is scrolled to when dropdown is opened', function(assert) {
+test('Selected option is visible when dropdown is opened', function(assert) {
   assert.expect(1);
 
   const selection = 'z-last-element';
+  // Set a low dropdown height to ensure that the last item is hidden
   select = this.subject({
     content: ['foo', 'bana$  na', 'bar ca', selection],
     selection,
     dropdownHeight: 30
   });
   this.append();
-  andThen(() => {
-    select.set('highlighted', selection);
-  });
+  // The highlighted property is set when the user hovers over the select field
+  // Lets programatically set it after rendering to emulate that behavior.
+  andThen(() => select.set('highlighted', selection));
   var selectElement = select.$();
   openDropdown(selectElement);
   andThen(() => {
-    assert.ok(isPresent(getOptionSelector(selection)),
-     'The last option is displayed');
+    assert.ok(isPresent(getOptionSelector(selection)), 'The last option is displayed');
   });
 });
 
-test('Selected option is not scrolled to when shouldEnsureVisible is false', function(assert) {
+test('Selected option is not visible when shouldEnsureVisible is false', function(assert) {
   assert.expect(2);
 
   const selection = 'z-last-element';
+  // Set a low dropdown height to ensure that the last item is hidden
   select = this.subject({
     content: ['foo', 'bana$  na', 'bar ca', selection],
     selection,
@@ -501,14 +499,13 @@ test('Selected option is not scrolled to when shouldEnsureVisible is false', fun
     dropdownHeight: 30
   });
   this.append();
-  andThen(() => {
-    select.set('highlighted', selection);
-  });
+  // The highlighted property is set when the user hovers over the select field
+  // Lets programatically set it after rendering to emulate that behavior.
+  andThen(() => select.set('highlighted', selection));
   var selectElement = select.$();
   openDropdown(selectElement);
   andThen(() => {
     assert.ok(isPresent('.dropdown-menu'),  'Dropdown menu is displayed');
-    assert.ok(isNotPresent(getOptionSelector(selection)),
-     'The last option is not displayed');
+    assert.ok(isNotPresent(getOptionSelector(selection)), 'The last option is not displayed');
   });
 });


### PR DESCRIPTION
This PR fixes an issue where the selected option is not visible when the select's dropdown is opened.

Steps:
Initialize a select field with a large number of options. The number of options should result in the dropdown appearing with a scroll bar.
Set the selection (selected option) to the last option (Or any option which must be scrolled to).
Open the dropdown
Bug: Although the selected option is highlighted, it is hidden. The user needs to scroll to the option. Due the another issue with respect the mouse over events, the dropdown does scroll to the selected option on hovering over the select field

@Addepar/trex @Addepar/pants @Addepar/ice 