### PR TITLE
Update label of selected item when selected options change

### DIFF
--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -463,7 +463,10 @@ export default Ember.Component.extend(
     if (!Ember.isNone(selection)) {
       const selectedOption = 
         selectableOptions.findBy(valuePath, selection[valuePath]);
-      this.set(`selection.${labelPath}`, selectedOption[labelPath]);
+        
+      if (!Ember.isNone(selectedOption)) {
+        this.set(`selection.${labelPath}`, selectedOption[labelPath]);
+      }
     }
   }, 'selectableOptions.[]', 'showDropdown'),
 

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -462,10 +462,10 @@ export default Ember.Component.extend(
     // Update display name of selected option
     if (!Ember.isNone(selection)) {
       const selectedOption = 
-        selectableOptions.findBy(valuePath, selection[valuePath]);
-        
+        selectableOptions.findBy(valuePath, Ember.get(selection, valuePath));
+
       if (!Ember.isNone(selectedOption)) {
-        this.set(`selection.${labelPath}`, selectedOption[labelPath]);
+        this.set(`selection.${labelPath}`, Ember.get(selectedOption, labelPath));
       }
     }
   }, 'selectableOptions.[]', 'showDropdown'),

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -446,12 +446,21 @@ export default Ember.Component.extend(
     return this.set('selection', content.findProperty(defaultPath));
   }, 'content.[]'),
   selectableOptionsDidChange: Ember.observer(function() {
-    var highlighted;
+    const selectableOptions = this.get('selectableOptions');
+    const selectedValue = this.get('selection.value');
+    let highlighted;
+    
     if (this.get('showDropdown')) {
       highlighted = this.get('highlighted');
-      if (!this.get('selectableOptions').contains(highlighted)) {
+      if (!selectableOptions.contains(highlighted)) {
         return this.set('highlighted', this.get('selectableOptions.firstObject'));
       }
+    }
+
+    // Update display name of selected option
+    if (!Ember.isNone(selectedValue)) {
+      const selectedOption = selectableOptions.findBy('value', selectedValue);
+      this.set('selection.displayName', selectedOption.displayName);
     }
   }, 'selectableOptions.[]', 'showDropdown'),
 

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -460,7 +460,7 @@ export default Ember.Component.extend(
     }
 
     // Update display name of selected option
-    if (!Ember.isNone(selection)) {
+    if (!Ember.isNone(selection) && !Ember.isEmpty(labelPath) && !Ember.isEmpty(valuePath)) {
       const selectedOption = 
         selectableOptions.findBy(valuePath, Ember.get(selection, valuePath));
 

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -447,7 +447,9 @@ export default Ember.Component.extend(
   }, 'content.[]'),
   selectableOptionsDidChange: Ember.observer(function() {
     const selectableOptions = this.get('selectableOptions');
-    const selectedValue = this.get('selection.value');
+    const selection = this.get('selection');
+    const labelPath = this.get('optionLabelPath');
+    const valuePath = this.get('optionValuePath');
     let highlighted;
     
     if (this.get('showDropdown')) {
@@ -458,9 +460,10 @@ export default Ember.Component.extend(
     }
 
     // Update display name of selected option
-    if (!Ember.isNone(selectedValue)) {
-      const selectedOption = selectableOptions.findBy('value', selectedValue);
-      this.set('selection.displayName', selectedOption.displayName);
+    if (!Ember.isNone(selection)) {
+      const selectedOption = 
+        selectableOptions.findBy(valuePath, selection[valuePath]);
+      this.set(`selection.${labelPath}`, selectedOption[labelPath]);
     }
   }, 'selectableOptions.[]', 'showDropdown'),
 


### PR DESCRIPTION
This PR is a small update to the select component to update the selected item label when the contents of 'selectableOptions` change.

My current use case is a filter dropdown select where each select option contains an item count (e.g. Filter: Selected Items (5)) and the item count (the `displayName` field) may change. I am currently able to keep the `displayName` text of select options updated, but I would like the currently selected item's `displayName` to also update with this change.

@Addepar/ice