### PR TITLE
ADPR-40383 Add optional footer view to ember-typeahead

### DIFF
--- a/addon/components/typeahead-component.js
+++ b/addon/components/typeahead-component.js
@@ -15,6 +15,19 @@ export default SelectComponent.extend({
     }
   }),
 
+  /**
+   * Whether or not to display the footer view
+   * @type {Boolean}
+   */
+  showFooter: false,
+
+  /**
+   * An optional view to be displayed in the typeahead dropdown below the list
+   * of options
+   * @type {String}
+   */
+  footerView: null,
+
   userDidSelect(selection) {
     this._super(selection);
     this.set('query', this.get('selection'));

--- a/addon/components/typeahead-component.js
+++ b/addon/components/typeahead-component.js
@@ -16,12 +16,6 @@ export default SelectComponent.extend({
   }),
 
   /**
-   * Whether or not to display the footer view
-   * @type {Boolean}
-   */
-  showFooter: false,
-
-  /**
    * An optional view to be displayed in the typeahead dropdown below the list
    * of options
    * @type {String}

--- a/app/templates/typeahead.hbs
+++ b/app/templates/typeahead.hbs
@@ -11,10 +11,8 @@
       contentBinding="groupedContent"
       itemViewClassBinding="itemView"
     }}
-    {{#if showFooter}}
-      {{#if footerView}}
-        {{view footerView}}
-      {{/if}}
+    {{#if footerView}}
+      {{view footerView}}
     {{/if}}
   </div>
 {{/unless}}

--- a/app/templates/typeahead.hbs
+++ b/app/templates/typeahead.hbs
@@ -11,5 +11,10 @@
       contentBinding="groupedContent"
       itemViewClassBinding="itemView"
     }}
+    {{#if showFooter}}
+      {{#if footerView}}
+        {{view footerView}}
+      {{/if}}
+    {{/if}}
   </div>
 {{/unless}}


### PR DESCRIPTION
This will enable instances of ember-typeahead to incorporate a footer displayed beneath the list of options that can be shown or hidden by toggling the `showFooter` flag.

@Addepar/ice 