### PR TITLE
Hide dropdown when typeahead loses focus

### DIFF
--- a/addon/components/typeahead-component.js
+++ b/addon/components/typeahead-component.js
@@ -12,6 +12,9 @@ export default SelectComponent.extend({
     valueBinding: 'parentView.query',
     focusIn() {
       this.set('parentView.showDropdown', true);
+    },
+    focusOut() {
+      this.set('parentView.showDropdown', false);
     }
   }),
 


### PR DESCRIPTION
This change hides the dropdown when the typeahead element loses focus.

@Addepar/ice 