### PR TITLE
Revert "Hide dropdown when typeahead loses focus"

### DIFF
--- a/addon/components/typeahead-component.js
+++ b/addon/components/typeahead-component.js
@@ -12,9 +12,6 @@ export default SelectComponent.extend({
     valueBinding: 'parentView.query',
     focusIn() {
       this.set('parentView.showDropdown', true);
-    },
-    focusOut() {
-      this.set('parentView.showDropdown', false);
     }
   }),
 


### PR DESCRIPTION
This reverts commit 8be839f9fb8ccfd4bd8aa2ad0e126e7ba62872c5.

Revert focusOut change to typeahead because it's preventing selection from happening.