### PR TITLE
[Fix] Prevent BodyEventListener from removing all body event handlers when destroyed

### DIFF
--- a/addon/mixins/body-event-listener.js
+++ b/addon/mixins/body-event-listener.js
@@ -44,7 +44,9 @@ export default Ember.Mixin.create({
     return $(this.get('bodyElementSelector')).on("click", this._clickHandler);
   },
   _removeDocumentHandlers: function() {
-    $(this.get('bodyElementSelector')).off("click", this._clickHandler);
+    if (this._clickHandler) {
+      $(this.get('bodyElementSelector')).off("click", this._clickHandler);
+    }
     return this._clickHandler = null;
   }
 });

--- a/addon/mixins/body-event-listener.js
+++ b/addon/mixins/body-event-listener.js
@@ -14,8 +14,8 @@ export default Ember.Mixin.create({
     return Ember.run.next(this, this._setupDocumentHandlers);
   },
   willDestroyElement: function() {
+    this._removeDocumentHandlers();
     this._super();
-    return this._removeDocumentHandlers();
   },
   _setupDocumentHandlers: function() {
     var _this = this;


### PR DESCRIPTION
When a component using BodyEventListener is destroyed, the corresponding event handler for the function is removed from the DOM in `_removeDocumentHandlers`. 

However, in some cases, `this._clickHandler` was already destroyed at the time when `_removeDocumentHandlers` is called. When `$(this.get('bodyElementSelector')).off("click", this._clickHandler);` is run and `this._clickHandler` is undefined, all the event handlers on `bodyElementSelector` are removed, instead of just one specific one for the destroyed component.

I moved `this._super()` beneath `this._removeDocumentHandlers()` in `willDestroyElement` so that event handlers can be removed first. And also added a null check in the `_removeDocumentHandlers` function to prevent it from running when `this._clickHandler` is null or undefined.

@Addepar/ice 
cc @embooglement @Addepar/twex 