### PR TITLE
Don't open dropdown on keyDown if select is disabled

### DIFF
--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -513,7 +513,7 @@ export default Ember.Component.extend(
 
   keyDown: function(event) {
     var acceptedKeys, map, method, ref;
-    if (this.get('isDestroyed') || this.get('isDestroying')) {
+    if (this.get('disabled') || this.get('isDestroyed') || this.get('isDestroying')) {
       return;
     }
     this.setFocus();

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -509,3 +509,22 @@ test('Selected option is not visible when shouldEnsureVisible is false', functio
     assert.ok(isNotPresent(getOptionSelector(selection)), 'The last option is not displayed');
   });
 });
+
+test('Dropdown does not open on key event when select is disabled', function(assert) {
+  assert.expect(1);
+
+  select = this.subject({
+    content: ['foo', 'bar'],
+    selection: 'foo',
+    disabled: true
+  });
+  this.append();
+
+  var selectElement = select.$();
+  selectElement.focus();
+  pressDownArrow(selectElement);
+
+  andThen(() => {
+    assert.ok(isNotPresent('.ember-select-results', selectElement), 'The dropdown does not open');
+  });
+});


### PR DESCRIPTION
Fixes an issue where a disabled select would still open its dropdown on keyDown. Expected behavior is that dropdown will not open when select is disabled.

@Addepar/ice 
cc @Addepar/twex 