### PR TITLE
Select Component: Send valueChanged when query is cleared

### DIFF
--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -262,7 +262,8 @@ export default Ember.Component.extend(
         });
       // clear the query string when dropdown is hidden
       } else {
-        return this.set('value', '');
+        this.set('value', '');
+        this.get('parentView').send('valueChanged', '');
       }
     }, 'parentView.showDropdown'),
 

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -173,6 +173,26 @@ test('Test userSelected action', function() {
   });
 });
 
+test('Test valueChanged action when dropdown is closed and query is cleared', function() {
+  expect(1);
+  select = this.subject({
+    content: ['bar', 'baz']
+  });
+  const spy = sinon.spy(select, 'sendAction');
+  this.append();
+
+  const selectElement = select.$();
+  const searchInput = find('input', selectElement);
+
+  openDropdown(selectElement);
+  fillIn(searchInput, 'bar');
+  pressEsc(selectElement);
+
+  andThen(() => {
+    ok(spy.calledWithExactly('valueChanged', ''), 'valueChanged is sent with empty string when query is cleared');
+  });
+});
+
 test('Test selection label', function() {
   var data;
   expect(2);


### PR DESCRIPTION
Currently the query text in select component is automatically cleared when the dropdown is hidden, via Enter key, Escape key or focus out. Select component has an existing `valueChanged` action, but it's currently only sent when a user manually types into the query text input and not when the input is cleared programmatically. 

I'd like to send the `valueChanged` action on clear, so that parent contexts can be notified that the query has changed. This is especially relevant for selects that use server side search, so they can then reissue the search with an empty query string for the next time the dropdown is opened.

@Addepar/ice 
@Addepar/twex 