### PR TITLE
Use vertical-collection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,17 @@ env:
     # - EMBER_TRY_SCENARIO=ember-release
     # - EMBER_TRY_SCENARIO=ember-beta
     # - EMBER_TRY_SCENARIO=ember-canary
+    - EMBER_TRY_SCENARIO=ember-1.11
+    - EMBER_TRY_SCENARIO=ember-1.12
+    - EMBER_TRY_SCENARIO=ember-1.13
+    - EMBER_TRY_SCENARIO=ember-2.0
     - EMBER_TRY_SCENARIO=ember-default
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-1.12
+    - env: EMBER_TRY_SCENARIO=ember-2.0
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/addon/components/carousel-component.js
+++ b/addon/components/carousel-component.js
@@ -98,18 +98,24 @@ export default Ember.Component.extend({
       this.$nextItem.addClass(direction);
     }
     // Bootstrap has this method for listening on end of transition
-    return this._onTransitionEnd(this.$nextItem, function() {
-      _this.$nextItem.off($.support.transition.end);
+    return this._onTransitionEnd(this.$nextItem, () => {
+      this.$nextItem.off($.support.transition.end);
       // This code is async and ember-testing requires us to wrap any code with
         // asynchronous side-effects in an Ember.run
-      Ember.run(_this, function() {
+      Ember.run(() => {
         this.set('activeIndex', nextIndex);
         this.$nextItem.removeClass([type, direction].join(' ')).addClass('active');
         $active.removeClass(['active', direction].join(' '));
         this.set('sliding', false);
-        return this.send('transitionEnded');
+        this.send('transitionEnded');
+
+        Ember.run.schedule('afterRender', () => {
+          // Have any vertical-collection based select
+          // refresh its contents now that the list is visible
+          window.dispatchEvent(new Event('resize'));
+        });
       });
-      return _this.$nextItem = null;
+      this.$nextItem = null;
     });
   },
   _onTransitionEnd: function($el, callback) {

--- a/addon/components/multi-select-component.js
+++ b/addon/components/multi-select-component.js
@@ -59,15 +59,15 @@ export default SelectComponent.extend({
 
   searchView: Ember.TextField.extend({
     "class": 'ember-select-input',
-    valueBinding: 'parentView.query',
+    valueBinding: 'selectComponent.query',
     placeholder: Ember.computed(function() {
-      if (this.get('parentView.selections.length')) {
-        return this.get('parentView.persistentPlaceholder');
+      if (this.get('selectComponent.selections.length')) {
+        return this.get('selectComponent.persistentPlaceholder');
       }
-      return this.get('parentView.placeholder') || this.get('parentView.persistentPlaceholder');
-    }).property('parentView.placeholder', 'parentView.persistentPlaceholder', 'parentView.selections.length'),
+      return this.get('selectComponent.placeholder') || this.get('selectComponent.persistentPlaceholder');
+    }).property('selectComponent.placeholder', 'selectComponent.persistentPlaceholder', 'selectComponent.selections.length'),
     click: function() {
-      return this.set('parentView.showDropdown', true);
+      return this.set('selectComponent.showDropdown', true);
     }
   }),
 

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -220,8 +220,8 @@ export default Ember.Component.extend(
   selectedItemView: Ember.computed(function() {
     return this.get('itemView').extend({
       tagName: 'span',
-      labelPath: Ember.computed.alias('controller.optionLabelPath'),
-      context: Ember.computed.alias('controller.selection'),
+      labelPath: Ember.computed.alias('selectComponent.optionLabelPath'),
+      context: Ember.computed.alias('selectComponent.selection'),
       /**
       * Note: This view is an extension of the view used to display
       * each option in the dropdown list.
@@ -245,15 +245,15 @@ export default Ember.Component.extend(
   }, 'selection', 'optionLabelPath')),
 
   searchView: DebouncedTextComponent.extend({
-    placeholder: Ember.computed.alias('parentView.placeholder'),
-    valueBinding: 'parentView.query',
+    placeholder: Ember.computed.alias('selectComponent.placeholder'),
+    valueBinding: 'selectComponent.query',
     // we want to focus on search input when dropdown is opened. We need to put
     // this in a run loop to wait for the event that triggers the showDropdown
     // to finishes before trying to focus the input. Otherwise, focus when be
     // "stolen" from us.
     showDropdownDidChange: Ember.observer(function() {
       // when closing, don't need to focus the now-hidden search box
-      if (this.get('parentView.showDropdown')) {
+      if (this.get('selectComponent.showDropdown')) {
         return Ember.run.schedule('afterRender', this, function() {
           if ((this.get('_state') || this.get('state')) === 'inDOM') {
             return this.$().focus();
@@ -262,9 +262,9 @@ export default Ember.Component.extend(
       // clear the query string when dropdown is hidden
       } else {
         this.set('value', '');
-        this.get('parentView').send('valueChanged', '');
+        this.get('selectComponent').send('valueChanged', '');
       }
-    }, 'parentView.showDropdown'),
+    }, 'selectComponent.showDropdown'),
 
     /**
       Delegates to parent view (The select component) to propagate this data up.
@@ -272,7 +272,7 @@ export default Ember.Component.extend(
       @override
     */
     propagateNewText: function(newText) {
-      this.get('parentView').send('valueChanged', newText);
+      this.get('selectComponent').send('valueChanged', newText);
     },
   }),
 

--- a/addon/components/typeahead-component.js
+++ b/addon/components/typeahead-component.js
@@ -8,10 +8,10 @@ export default SelectComponent.extend({
 
   searchView: Ember.TextField.extend({
     class: 'ember-select-input',
-    placeholderBinding: 'parentView.placeholder',
-    valueBinding: 'parentView.query',
+    placeholderBinding: 'selectComponent.placeholder',
+    valueBinding: 'selectComponent.query',
     focusIn() {
-      this.set('parentView.showDropdown', true);
+      this.set('selectComponent.showDropdown', true);
     }
   }),
 
@@ -24,6 +24,6 @@ export default SelectComponent.extend({
 
   userDidSelect(selection) {
     this._super(selection);
-    this.set('query', this.get('selection'));
+    this.set('query', selection);
   }
 });

--- a/addon/mixins/popover.js
+++ b/addon/mixins/popover.js
@@ -40,7 +40,6 @@ export default Ember.Mixin.create(
       return this.get('contentViewClass');
     }
     return Ember.View.extend({
-      content: Ember.computed.alias('parentView.content'),
       templateName: 'view-parent-view-content'
     });
   }).property('contentViewClass'),

--- a/addon/styles/select.less
+++ b/addon/styles/select.less
@@ -4,20 +4,10 @@
 
 /* Variables
 -------------------------------------------------- */
-// Note: Important that this is synchronized with the list-view rowHeight
+// Note: Important that this is synchronized with the in-JS vertical-collection rowHeight
 @rowHeight: 26px;
 @input-border-focus: #4d90fe;
 @input-border: #cccccc;
-
-/* List View - Note: Required for list-view to work
--------------------------------------------------- */
-.ember-list-view {
-  overflow: auto;
-  position: relative;
-}
-.ember-list-item-view {
-  position: absolute;
-}
 
 /* Ember Select
 -------------------------------------------------- */
@@ -306,7 +296,6 @@
   overflow-y: auto;
 
   .ember-select-result-item {
-    position: absolute;
     display: block;
     white-space: nowrap;
     width: 100%;
@@ -359,6 +348,7 @@
 
   .dropdown-menu {
     // This causes stress
+    width: 200px;
     min-width: 200px;
     max-width: 600px;
     padding: 0;

--- a/addon/views/multi-select-item.js
+++ b/addon/views/multi-select-item.js
@@ -3,6 +3,6 @@ import SelectOption from './select-option';
 export default SelectOption.extend({
   processDropDownShown: function() {
     this._super();
-    return this.get('controller').focusTextField();
+    return this.get('selectComponent').focusTextField();
   }
 });

--- a/addon/views/multi-select-option.js
+++ b/addon/views/multi-select-option.js
@@ -4,7 +4,6 @@ export default Ember.View.extend({
   tagName: 'li',
   templateName: 'multi-select-item',
   classNames: 'ember-select-search-choice',
-  labelPath: Ember.computed.alias('controller.optionLabelPath'),
   didInsertElement: function() {
     this._super();
     return this.labelPathDidChange();
@@ -12,8 +11,8 @@ export default Ember.View.extend({
   labelPathDidChange: Ember.observer(function() {
     var labelPath, path;
     labelPath = this.get('labelPath');
-    path = labelPath ? "context." + labelPath : 'context';
+    path = labelPath ? "content." + labelPath : 'content';
     Ember.defineProperty(this, 'label', Ember.computed.alias(path));
     return this.notifyPropertyChange('label');
-  }, 'context', 'labelPath')
+  }, 'content', 'labelPath')
 });

--- a/addon/views/multi-select-tooltip-item.js
+++ b/addon/views/multi-select-tooltip-item.js
@@ -3,6 +3,6 @@ import SelectTooltipOption from './select-tooltip-option';
 export default SelectTooltipOption.extend({
   processDropDownShown: function() {
     this._super();
-    return this.get('controller').focusTextField();
+    return this.get('selectComponent').focusTextField();
   }
 });

--- a/addon/views/select-option.js
+++ b/addon/views/select-option.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const { get } = Ember;
+
 // The view for each item in the select.
 export default Ember.View.extend({
   tagName: 'li',
@@ -7,11 +9,10 @@ export default Ember.View.extend({
   layoutName: 'select-item-layout',
   classNames: 'ember-select-result-item',
   classNameBindings: Ember.A(['content.isGroupOption:ember-select-group', 'isHighlighted:highlighted']),
-  labelPath: Ember.computed.alias('controller.optionLabelPath'),
   isHighlighted: Ember.computed(function() {
-    return this.get('controller.highlighted') === this.get('content');
-  }).property('controller.highlighted', 'content'),
-  labelPathDidChange: Ember.observer(function() {
+    return this.get('highlighted') === this.get('content');
+  }).property('highlighted', 'content'),
+  labelPathDidChange: Ember.on('init', Ember.observer(function() {
     var labelPath, path;
     labelPath = this.get('labelPath');
 
@@ -23,9 +24,9 @@ export default Ember.View.extend({
     // 'context.#{labelPath}'
     Ember.defineProperty(this, 'label', Ember.computed.alias(path));
     return this.notifyPropertyChange('label');
-  }, 'content', 'labelPath'),
+  }, 'content', 'labelPath')),
   processDropDownShown: function() {
-    return this.get('controller').send('hideDropdown');
+    return this.get('selectComponent').send('hideDropdown');
   },
   didInsertElement: function() {
     this._super();
@@ -40,15 +41,16 @@ export default Ember.View.extend({
     return this.set('content', context);
   },
   click: function() {
-    if (this.get('content.isGroupOption')) {
+    let selection = this.get('content');
+    if (get(selection, 'isGroupOption')) {
       return;
     }
-    this.set('controller.selection', this.get('content'));
-    this.get('controller').userDidSelect(this.get('content'));
+    this.set('selectComponent.selection', selection);
+    this.get('selectComponent').userDidSelect(selection);
     // if there's a selection and the dropdown is unexpanded, we want to
     // propagate the click event
     // if the dropdown is expanded and we select something, don't propagate
-    if (this.get('controller.showDropdown')) {
+    if (this.get('showDropdown')) {
       this.processDropDownShown();
       return false;
     }
@@ -57,6 +59,6 @@ export default Ember.View.extend({
     if (this.get('content.isGroupOption')) {
       return;
     }
-    return this.set('controller.highlighted', this.get('content'));
+    return this.set('highlighted', this.get('content'));
   }
 });

--- a/addon/views/select-option.js
+++ b/addon/views/select-option.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
-import ListItemView from 'ember-list-view/list-item-view';
 
 // The view for each item in the select.
-export default ListItemView.extend({
+export default Ember.View.extend({
   tagName: 'li',
   templateName: 'select-item',
   layoutName: 'select-item-layout',

--- a/app/templates/multi-select-item.hbs
+++ b/app/templates/multi-select-item.hbs
@@ -1,4 +1,4 @@
 <div>{{view.label}}</div>
 <a class="ember-select-search-choice-close" href="#" tabIndex="-1"
-  {{action "removeSelectItem" view.content}}>×
+  {{action "removeSelectItem" view.content target=view.selectComponent}}>×
 </a>

--- a/app/templates/multi-select.hbs
+++ b/app/templates/multi-select.hbs
@@ -1,24 +1,44 @@
 <div {{bind-attr class=":ember-select-container :ember-select-multi :dropdown-toggle :js-dropdown-toggle hasFocus:ember-select-focus"}}>
   <ul {{bind-attr class=":ember-select-choices choicesFieldClass"}}>
-    {{each selections itemViewClass=view.selectionItemView}}
+    {{#each selections as |item|}}
+      {{view selectionItemView
+        content=item
+        labelPath=optionLabelPath
+        selectComponent=this
+      }}
+    {{/each}}
     <li class="ember-select-search-field">
       {{! Invisible span containing the placeholder/query text, used to set
           the width of its parent element. }}
       <span class="invisible-placeholder">{{invisiblePlaceholderText}}</span>
-      {{view searchView}}
+      {{view searchView selectComponent=this}}
     </li>
   </ul>
 </div>
 
 <div class="dropdown-menu js-dropdown-menu">
   <ul class="ember-select-results" style={{collectionStyle}}>
+    {{!
+      This if statement is a bit of a hack. The visibility of this DOM is
+      managed by jQuery via the js-dropdown-menu class. This template should
+      be refactored to use Ember state for the dropdown instead of imperative
+      jQuery soup.
+    }}
     {{#if showDropdown}}
       {{#vertical-collection groupedContent
         estimateHeight=rowHeight
         staticHeight=true
         idForFirstItem=highlightedIdentity
       as |item|}}
-        {{view itemView content=item}}
+        {{view itemView
+          content=item
+          highlighted=highlighted
+          labelPath=optionLabelPath
+          selection=selection
+          showDropdown=showDropdown
+          titleOnOptions=titleOnOptions
+          selectComponent=this
+        }}
       {{/vertical-collection}}
     {{/if}}
   </ul>

--- a/app/templates/multi-select.hbs
+++ b/app/templates/multi-select.hbs
@@ -11,14 +11,17 @@
 </div>
 
 <div class="dropdown-menu js-dropdown-menu">
-  {{view listView
-    tagName="ul"
-    classNames="ember-select-results"
-    heightBinding="dropdownHeight"
-    rowHeightBinding="rowHeight"
-    contentBinding="groupedContent"
-    itemViewClassBinding="itemView"
-  }}
+  <ul class="ember-select-results" style={{collectionStyle}}>
+    {{#if showDropdown}}
+      {{#vertical-collection groupedContent
+        estimateHeight=rowHeight
+        staticHeight=true
+        idForFirstItem=highlightedIdentity
+      as |item|}}
+        {{view itemView content=item}}
+      {{/vertical-collection}}
+    {{/if}}
+  </ul>
   {{#if hasNoResults}}
     <span class="ember-select-no-results">No results match "{{query}}"</span>
   {{/if}}

--- a/app/templates/popover.hbs
+++ b/app/templates/popover.hbs
@@ -3,5 +3,7 @@
   <h4 class="popover-title">{{title}}</h4>
 {{/if}}
 <div class="popover-content">
-  {{view view._contentViewClass}}
+  {{view _contentViewClass
+      content=content
+      popoverComponent=this}}
 </div>

--- a/app/templates/select-item-layout.hbs
+++ b/app/templates/select-item-layout.hbs
@@ -1,7 +1,7 @@
 {{#if view.content.isGroupOption}}
   {{view.content.name}}
 {{else}}
-  {{#if controller.titleOnOptions}}
+  {{#if view.titleOnOptions}}
     <span {{bind-attr title=view.label}}>
       {{view.label}}
     </span>

--- a/app/templates/select-item.hbs
+++ b/app/templates/select-item.hbs
@@ -1,4 +1,4 @@
-{{#if controller.titleOnOptions}}
+{{#if view.titleOnOptions}}
   <span {{bind-attr title=view.label}}>
     {{view.label}}
   </span>

--- a/app/templates/select-list-view-partial.hbs
+++ b/app/templates/select-list-view-partial.hbs
@@ -4,6 +4,14 @@
     staticHeight=true
     idForFirstItem=highlightedIdentity
   as |item|}}
-    {{view itemView content=item}}
+    {{view itemView
+      content=item
+      highlighted=highlighted
+      labelPath=optionLabelPath
+      selection=selection
+      showDropdown=showDropdown
+      titleOnOptions=titleOnOptions
+      selectComponent=this
+    }}
   {{/vertical-collection}}
 </ul>

--- a/app/templates/select-list-view-partial.hbs
+++ b/app/templates/select-list-view-partial.hbs
@@ -1,8 +1,9 @@
-{{view listView
-  tagName="ul"
-  classNames="ember-select-results"
-  heightBinding="dropdownHeight"
-  rowHeightBinding="rowHeight"
-  contentBinding="groupedContent"
-  itemViewClassBinding="itemView"
-}}
+<ul class="ember-select-results" style={{collectionStyle}}>
+  {{#vertical-collection groupedContent
+    estimateHeight=rowHeight
+    staticHeight=true
+    idForFirstItem=highlightedIdentity
+  as |item|}}
+    {{view itemView content=item}}
+  {{/vertical-collection}}
+</ul>

--- a/app/templates/select.hbs
+++ b/app/templates/select.hbs
@@ -2,7 +2,7 @@
   <a {{bind-attr class=":form-control :ember-select-choice buttonClass disabled:disabled
   hasFocus:ember-select-focus"}}>
     {{#if selection}}
-      {{view selectedItemView contentBinding=selection}}
+      {{view selectedItemView content=selection selectComponent=this}}
       <i {{bind-attr class=view.dropdownToggleIcon}}></i>
     {{else}}
       <span>{{prompt}}</span>
@@ -13,7 +13,7 @@
 <div {{bind-attr class=":dropdown-menu :js-dropdown-menu dropdownMenuClass isDropdownMenuPulledRight:pull-right"}}>
   {{#unless isSelect}}
     <div class="ember-select-search">
-      {{view searchView}}
+      {{view searchView selectComponent=this}}
     </div>
   {{/unless}}
   {{#if showDropdown}}
@@ -24,7 +24,7 @@
     {{#if contentIsEmpty}}
       <div class="ember-select-empty-content">
         {{#if emptyContentView}}
-          {{view emptyContentView}}
+          {{view emptyContentView selectComponent=this}}
         {{/if}}
       </div>
     {{else}}
@@ -34,6 +34,6 @@
     {{/if}}
   {{/if}}
   {{#if selectMenuView}}
-    {{view selectMenuView}}
+    {{view selectMenuView selectComponent=this}}
   {{/if}}
 </div>

--- a/app/templates/typeahead.hbs
+++ b/app/templates/typeahead.hbs
@@ -3,14 +3,23 @@
 </div>
 {{#unless hasNoResults}}
   <div class="dropdown-menu">
-    {{view listView
-      tagName="ul"
-      classNames="ember-typeahead-results"
-      heightBinding="dropdownHeight"
-      rowHeightBinding="rowHeight"
-      contentBinding="groupedContent"
-      itemViewClassBinding="itemView"
-    }}
+    <ul class="ember-typeahead-results" style={{collectionStyle}}>
+      {{#vertical-collection groupedContent
+        estimateHeight=rowHeight
+        staticHeight=true
+        idForFirstItem=highlightedIdentity
+      as |item|}}
+        {{view itemView
+          content=item
+          highlighted=highlighted
+          labelPath=optionLabelPath
+          selection=selection
+          showDropdown=showDropdown
+          titleOnOptions=titleOnOptions
+          selectComponent=this
+        }}
+      {{/vertical-collection}}
+    </ul>
     {{#if footerView}}
       {{view footerView}}
     {{/if}}

--- a/app/templates/typeahead.hbs
+++ b/app/templates/typeahead.hbs
@@ -1,27 +1,32 @@
 <div>
-  {{view searchView classBinding="searchFieldClass" disabled=disabled}}
+  {{view searchView
+    classBinding="searchFieldClass"
+    disabled=disabled
+    selectComponent=this}}
 </div>
-{{#unless hasNoResults}}
-  <div class="dropdown-menu">
-    <ul class="ember-typeahead-results" style={{collectionStyle}}>
-      {{#vertical-collection groupedContent
-        estimateHeight=rowHeight
-        staticHeight=true
-        idForFirstItem=highlightedIdentity
-      as |item|}}
-        {{view itemView
-          content=item
-          highlighted=highlighted
-          labelPath=optionLabelPath
-          selection=selection
-          showDropdown=showDropdown
-          titleOnOptions=titleOnOptions
-          selectComponent=this
-        }}
-      {{/vertical-collection}}
-    </ul>
-    {{#if footerView}}
-      {{view footerView}}
-    {{/if}}
-  </div>
-{{/unless}}
+{{#if showDropdown}}
+  {{#unless hasNoResults}}
+    <div class="dropdown-menu">
+      <ul class="ember-typeahead-results" style={{collectionStyle}}>
+        {{#vertical-collection groupedContent
+          estimateHeight=rowHeight
+          staticHeight=true
+          idForFirstItem=highlightedIdentity
+        as |item|}}
+          {{view itemView
+            content=item
+            highlighted=highlighted
+            labelPath=optionLabelPath
+            selection=selection
+            showDropdown=showDropdown
+            titleOnOptions=titleOnOptions
+            selectComponent=this
+          }}
+        {{/vertical-collection}}
+      </ul>
+      {{#if footerView}}
+        {{view footerView selectComponent=this}}
+      {{/if}}
+    </div>
+  {{/unless}}
+{{/if}}

--- a/app/templates/view-parent-view-content.hbs
+++ b/app/templates/view-parent-view-content.hbs
@@ -1,1 +1,1 @@
-{{view.parentView.content}}
+{{content}}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,59 @@
 /* eslint-env node */
 module.exports = {
+  useYarn: true,
   scenarios: [
+    {
+      name: 'ember-1.11',
+      bower: {
+        dependencies: {
+          'ember': '1.11.4'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-1.12',
+      bower: {
+        dependencies: {
+          'ember': '1.12.2'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-1.13',
+      bower: {
+        dependencies: {
+          'ember': '1.13.13'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-2.0',
+      bower: {
+        dependencies: {
+          'ember': '2.0.0'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
     {
       name: 'ember-lts-2.8',
       bower: {
@@ -22,54 +75,6 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-source': '~2.12.0'
-        }
-      }
-    },
-    {
-      name: 'ember-release',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#release'
-        },
-        resolutions: {
-          'ember': 'release'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-beta',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
-        },
-        resolutions: {
-          'ember': 'beta'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-canary',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
-        },
-        resolutions: {
-          'ember': 'canary'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "~2.16.2",
     "ember-cli-dependency-checker": "^2.0.0",
-    "ember-cli-htmlbars": "~1.3.3",
-    "ember-cli-htmlbars-inline-precompile": "~0.3.0",
+    "ember-cli-htmlbars": "~2.0.3",
+    "ember-cli-htmlbars-inline-precompile": "~1.0.2",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-uglify": "^2.0.0",
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@html-next/vertical-collection": "1.0.0-beta.10",
-    "ember-cli-babel": "^5.0.0",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-less": "~1.3.1",
     "lodash": "~4.17.10"
   },

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "ember-addon"
   ],
   "dependencies": {
+    "@html-next/vertical-collection": "1.0.0-beta.10",
     "ember-cli-babel": "^5.0.0",
-    "ember-list-view": "0.0.5",
     "ember-cli-less": "~1.3.1",
     "lodash": "~4.17.10"
   },

--- a/tests/dummy/app/templates/ember-widgets/overview.hbs
+++ b/tests/dummy/app/templates/ember-widgets/overview.hbs
@@ -28,7 +28,7 @@
       <h3>Dependencies</h3>
       <ul class="styled">
         <li><a target="_BLANK" href="http://emberjs.com/">Ember.js</a></li>
-        <li><a target="_BLANK" href="http://emberjs.com/list-view/">List-View</a></li>
+        <li><a target="_BLANK" href="https://github.com/html-next/vertical-collection">vertical-collection</a></li>
         <li><a target="_BLANK" href="http://getbootstrap.com/">Bootstrap (V3)</a></li>
         <li><a target="_BLANK" href="http://lodash.com/">Lo-Dash</a></li>
         <li><a target="_BLANK" href="http://jquery.com/">jQuery</a></li>

--- a/tests/dummy/app/templates/ember-widgets/select.hbs
+++ b/tests/dummy/app/templates/ember-widgets/select.hbs
@@ -1,6 +1,6 @@
 <div class="col-md-10 col-md-offset-2 left-border main-content-container">
   <h2>Select <small> Ember.Widgets.Select</small></h2>
-  <p class="elevated">Ember select is a Ember.js based replacement for select boxes. It supports searching, remote data sets, and infinite scrolling of results. This component&#39;s design was inspired by the excellent <a target="_BLANK" href="http://harvesthq.github.io/chosen/">Chosen</a> jquery plugin and <a target="_BLANK" href="http://ivaynberg.github.io/select2/">Select2</a>. Uses the <a target="_BLANK" href="https://github.com/emberjs/list-view">ember list view</a> for lazily rendering large arrays of content.</p>
+  <p class="elevated">Ember select is a Ember.js based replacement for select boxes. It supports searching, remote data sets, and infinite scrolling of results. This component&#39;s design was inspired by the excellent <a target="_BLANK" href="http://harvesthq.github.io/chosen/">Chosen</a> jquery plugin and <a target="_BLANK" href="http://ivaynberg.github.io/select2/">Select2</a>. Uses the <a target="_BLANK" href="https://github.com/html-next/vertical-collection">vertical-collection</a> for lazily rendering large arrays of content.</p>
 
   <div class="row">
     <div class="col-md-6">

--- a/tests/integration/multi-select-component-test.js
+++ b/tests/integration/multi-select-component-test.js
@@ -35,7 +35,7 @@ var content = [
 var multiSelect, app;
 
 moduleForComponent('multi-select-component', '[Integration] Multi select component', {
-  needs: ['template:multi-select', 'template:multi-select-item', 'template:select-item-layout', 'template:select-item'],
+  needs: ['template:multi-select', 'template:multi-select-item', 'template:select-item-layout', 'template:select-item', 'component:vertical-collection'],
 
   setup: function() {
     app = startApp();

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -507,6 +507,28 @@ test('Selected option is visible when dropdown is opened', function(assert) {
   });
 });
 
+test('Selected object option is visible when dropdown is opened', function(assert) {
+  assert.expect(1);
+
+  const selection = {key: 'z-last-element'};
+  // Set a low dropdown height to ensure that the last item is hidden
+  select = this.subject({
+    content: [{key: 'foo'}, {key: 'bana$  na'}, {key: 'bar ca'}, selection],
+    selection,
+    optionLabelPath: 'key',
+    dropdownHeight: 30
+  });
+  this.append();
+  // The highlighted property is set when the user hovers over the select field
+  // Lets programatically set it after rendering to emulate that behavior.
+  andThen(() => select.set('highlighted', selection));
+  var selectElement = select.$();
+  openDropdown(selectElement);
+  andThen(() => {
+    assert.ok(isPresent(getOptionSelector(selection.key)), 'The last option is displayed');
+  });
+});
+
 test('Selected option is not visible when shouldEnsureVisible is false', function(assert) {
   assert.expect(2);
 

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -36,7 +36,8 @@ moduleForComponent('select-component', '[Integration] Select component', {
     'template:select',
     'template:select-item',
     'template:select-item-layout',
-    'template:select-list-view-partial'
+    'template:select-list-view-partial',
+    'component:vertical-collection'
   ],
 
   setup: function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,39 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
+"@html-next/vertical-collection@1.0.0-beta.10":
+  version "1.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/@html-next/vertical-collection/-/vertical-collection-1.0.0-beta.10.tgz#2090dc4bbc423fa30e8a152a1a8364ff5b6fc398"
+  dependencies:
+    babel-plugin-transform-es2015-block-scoping "^6.24.1"
+    babel6-plugin-strip-class-callcheck "^6.0.0"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-rollup "^2.0.0"
+    ember-cli-babel "^6.6.0"
+    ember-cli-htmlbars "^2.0.3"
+    ember-cli-version-checker "^2.1.0"
+    ember-compatibility-helpers "^0.1.2"
+    ember-raf-scheduler "0.1.0"
+
+"@types/acorn@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.3.tgz#d1f3e738dde52536f9aad3d3380d14e448820afd"
+  dependencies:
+    "@types/estree" "*"
+
+"@types/estree@*":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+
+"@types/estree@0.0.38":
+  version "0.0.38"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"
+
+"@types/node@^9.6.0":
+  version "9.6.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.15.tgz#8a5a313ea0a43a95277235841be5d3f5fb3dfeda"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -38,7 +71,13 @@ accepts@~1.3.4, accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
-acorn@^5.2.1:
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
+  dependencies:
+    acorn "^5.0.0"
+
+acorn@^5.0.0, acorn@^5.2.1, acorn@^5.5.3:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
@@ -76,6 +115,12 @@ amd-name-resolver@0.0.7:
 amd-name-resolver@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.0.0.tgz#0e593b28d6fa3326ab1798107edaea961046e8d8"
+  dependencies:
+    ensure-posix-path "^1.0.1"
+
+amd-name-resolver@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz#fc41b3848824b557313897d71f8d5a0184fbe679"
   dependencies:
     ensure-posix-path "^1.0.1"
 
@@ -596,7 +641,7 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.23.0:
+babel-plugin-transform-es2015-block-scoping@^6.23.0, babel-plugin-transform-es2015-block-scoping@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
   dependencies:
@@ -877,6 +922,10 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
+
+babel6-plugin-strip-class-callcheck@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/babel6-plugin-strip-class-callcheck/-/babel6-plugin-strip-class-callcheck-6.0.0.tgz#de841c1abebbd39f78de0affb2c9a52ee228fddf"
 
 babylon@^5.8.38:
   version "5.8.38"
@@ -1322,6 +1371,22 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli
     quick-temp "^0.1.3"
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
+
+broccoli-rollup@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-2.1.0.tgz#94d703625c24dbad2e57789508f63ccfcbb13c00"
+  dependencies:
+    "@types/node" "^9.6.0"
+    amd-name-resolver "^1.2.0"
+    broccoli-plugin "^1.2.1"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    magic-string "^0.24.0"
+    node-modules-path "^1.0.1"
+    rollup "^0.57.1"
+    symlink-or-copy "^1.1.8"
+    walk-sync "^0.3.1"
 
 broccoli-slow-trees@^3.0.1:
   version "3.0.1"
@@ -1850,6 +1915,12 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-time@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/date-time/-/date-time-2.1.0.tgz#0286d1b4c769633b3ca13e1e62558d2dbdc2eba2"
+  dependencies:
+    time-zone "^1.0.0"
+
 debug@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
@@ -2105,6 +2176,15 @@ ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@~1.3.3:
     json-stable-stringify "^1.0.0"
     strip-bom "^2.0.0"
 
+ember-cli-htmlbars@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.3.tgz#e116e1500dba12f29c94b05b9ec90f52cb8bb042"
+  dependencies:
+    broccoli-persistent-filter "^1.0.3"
+    hash-for-dep "^1.0.2"
+    json-stable-stringify "^1.0.0"
+    strip-bom "^3.0.0"
+
 ember-cli-inject-live-reload@^1.4.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.7.0.tgz#af94336e015336127dfb98080ad442bb233e37ed"
@@ -2313,6 +2393,14 @@ ember-cli@~2.16.2:
     walk-sync "^0.3.0"
     yam "0.0.22"
 
+ember-compatibility-helpers@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.3.tgz#039a57e9f1a401efda0023c1e3650bd01cfd7087"
+  dependencies:
+    babel-plugin-debug-macros "^0.1.11"
+    ember-cli-version-checker "^2.0.0"
+    semver "^5.4.1"
+
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
@@ -2322,10 +2410,6 @@ ember-disable-proxy-controllers@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-disable-proxy-controllers/-/ember-disable-proxy-controllers-1.0.1.tgz#1254eeec0ba025c24eb9e8da611afa7b38754281"
   dependencies:
     ember-cli-babel "^5.0.0"
-
-ember-list-view@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/ember-list-view/-/ember-list-view-0.0.5.tgz#433c7ca23daba466fe67ef8c76ddb2be3be185f6"
 
 ember-load-initializers@^1.0.0:
   version "1.1.0"
@@ -2344,6 +2428,12 @@ ember-qunit@^3.3.2:
     ember-cli-babel "^6.3.0"
     ember-cli-test-loader "^2.2.0"
     qunit "^2.5.0"
+
+ember-raf-scheduler@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-raf-scheduler/-/ember-raf-scheduler-0.1.0.tgz#a22a02d238c374499231c03ab9c5b9887c72a853"
+  dependencies:
+    ember-cli-babel "^6.6.0"
 
 ember-resolver@^4.0.0:
   version "4.5.5"
@@ -2496,6 +2586,10 @@ esprima@~3.0.0:
 esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
+estree-walker@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -3355,6 +3449,10 @@ ipaddr.js@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.6.0.tgz#e3fa357b773da619f26e95f049d055c72796f86b"
 
+irregular-plurals@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.4.0.tgz#2ca9b033651111855412f16be5d77c62a458a766"
+
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -3524,6 +3622,12 @@ is-primitive@^2.0.0:
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
+is-reference@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.1.0.tgz#50e6ef3f64c361e2c53c0416cdc9420037f2685b"
+  dependencies:
+    "@types/estree" "0.0.38"
 
 is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -3759,6 +3863,10 @@ load-json-file@^1.0.0:
 loader.js@^4.2.3:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.7.0.tgz#a1a52902001c83631efde9688b8ab3799325ef1f"
+
+locate-character@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-2.0.5.tgz#f2d2614d49820ecb3c92d80d193b8db755f74c0f"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -4128,6 +4236,12 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+magic-string@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.24.0.tgz#1b396d26406188f1fa3730a68229562d36a1c2f2"
+  dependencies:
+    sourcemap-codec "^1.4.1"
+
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -4236,7 +4350,7 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-micromatch@^2.1.5, micromatch@^2.3.7:
+micromatch@^2.1.5, micromatch@^2.3.11, micromatch@^2.3.7:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -4426,7 +4540,7 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-modules-path@^1.0.0:
+node-modules-path@^1.0.0, node-modules-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/node-modules-path/-/node-modules-path-1.0.1.tgz#40096b08ce7ad0ea14680863af449c7c75a5d1c8"
 
@@ -4678,6 +4792,10 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-ms@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -4778,6 +4896,12 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+plur@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/plur/-/plur-2.1.2.tgz#7482452c1a0f508e3e344eaec312c91c29dc655a"
+  dependencies:
+    irregular-plurals "^1.0.0"
+
 portfinder@^1.0.7:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.13.tgz#bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9"
@@ -4793,6 +4917,13 @@ posix-character-classes@^0.1.0:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+pretty-ms@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-3.1.0.tgz#e9cac9c76bf6ee52fe942dd9c6c4213153b12881"
+  dependencies:
+    parse-ms "^1.0.0"
+    plur "^2.1.2"
 
 printf@^0.2.3:
   version "0.2.5"
@@ -5124,6 +5255,10 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
+require-relative@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -5191,6 +5326,29 @@ rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimra
 rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+
+rollup-pluginutils@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.2.0.tgz#64ba3f29988b84322bafa188a9f99ca731c95354"
+  dependencies:
+    estree-walker "^0.5.2"
+    micromatch "^2.3.11"
+
+rollup@^0.57.1:
+  version "0.57.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.57.1.tgz#0bb28be6151d253f67cf4a00fea48fb823c74027"
+  dependencies:
+    "@types/acorn" "^4.0.3"
+    acorn "^5.5.3"
+    acorn-dynamic-import "^3.0.0"
+    date-time "^2.1.0"
+    is-reference "^1.1.0"
+    locate-character "^2.0.5"
+    pretty-ms "^3.1.0"
+    require-relative "^0.8.7"
+    rollup-pluginutils "^2.0.1"
+    signal-exit "^3.0.2"
+    sourcemap-codec "^1.4.1"
 
 rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0, rsvp@^3.6.0:
   version "3.6.2"
@@ -5508,6 +5666,10 @@ source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
+sourcemap-codec@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz#c8fd92d91889e902a07aee392bdd2c5863958ba2"
+
 sourcemap-validator@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/sourcemap-validator/-/sourcemap-validator-1.1.0.tgz#00454547d1682186e1498a7208e022e8dfa8738f"
@@ -5656,6 +5818,10 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -5760,6 +5926,10 @@ testem@^1.18.0:
 through@^2.3.6, through@^2.3.8, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+time-zone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"
 
 tiny-lr@^1.0.3:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,10 +559,6 @@ babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
 
-babel-plugin-htmlbars-inline-precompile@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.1.1.tgz#a878c1771224429dd6e546ba6d39c2c35073be92"
-
 babel-plugin-htmlbars-inline-precompile@^0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.4.tgz#54b48168432bbc03f1f26f2e9090cb222bc78c75"
@@ -2088,7 +2084,7 @@ electron-to-chromium@^1.3.45:
   version "1.3.45"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz#458ac1b1c5c760ce8811a16d2bfbd97ec30bafb8"
 
-ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.3:
+ember-cli-babel@^5.0.0:
   version "5.2.8"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz#0356b03cc3fdff5d0f2ecaa46a0e1cfaebffd876"
   dependencies:
@@ -2143,7 +2139,7 @@ ember-cli-get-dependency-depth@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-dependency-depth/-/ember-cli-get-dependency-depth-1.0.0.tgz#e0afecf82a2d52f00f28ab468295281aec368d11"
 
-ember-cli-htmlbars-inline-precompile@^1.0.0:
+ember-cli-htmlbars-inline-precompile@^1.0.0, ember-cli-htmlbars-inline-precompile@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.2.tgz#5b544f664d5d9911f08cd979c5f70d8cb0ca2add"
   dependencies:
@@ -2153,30 +2149,7 @@ ember-cli-htmlbars-inline-precompile@^1.0.0:
     heimdalljs-logger "^0.1.7"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars-inline-precompile@~0.3.0:
-  version "0.3.13"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-0.3.13.tgz#942285711900408acd1e6ee1e7c6ce8114306edb"
-  dependencies:
-    babel-plugin-htmlbars-inline-precompile "^0.1.0"
-    ember-cli-babel "^5.1.3"
-    ember-cli-htmlbars "^1.0.0"
-    hash-for-dep "^1.0.2"
-    heimdalljs-logger "^0.1.7"
-    resolve "^1.3.3"
-    semver "^5.3.0"
-    silent-error "^1.1.0"
-
-ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@~1.3.3:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.4.tgz#461289724b34af372a6a0c4b6635819156963353"
-  dependencies:
-    broccoli-persistent-filter "^1.0.3"
-    ember-cli-version-checker "^1.0.2"
-    hash-for-dep "^1.0.2"
-    json-stable-stringify "^1.0.0"
-    strip-bom "^2.0.0"
-
-ember-cli-htmlbars@^2.0.3:
+ember-cli-htmlbars@^2.0.3, ember-cli-htmlbars@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.3.tgz#e116e1500dba12f29c94b05b9ec90f52cb8bb042"
   dependencies:


### PR DESCRIPTION
For ember-widgets to be usable in Ember 1.13, it must not be dependent upon list-view. This PR removes uses of list-view and replaces them with [vertical-collection](https://github.com/html-next/vertical-collection).

TODO:

* [x] Get basic vertical collection implementations to have equivalent styles
* [x] Test/implement multi select
* [x] Remove styles related to list-view
* [x] Remove list-view
* [x] Ensure the dropdown scrolls to the correct item when opened (seems to work, but there is a failing test)
* [ ] ~Add 1.12 to the build matrix, ensure it passes.~ I'm going to skip this, it seems like the test suite is fubar in 1.12. https://github.com/Addepar/ember-widgets/pull/266
* [x] Add 1.13 to the build matrix, ensure it passes.