### PR TITLE
View registry 1.13 compat

### DIFF
--- a/addon/components/modal-component.js
+++ b/addon/components/modal-component.js
@@ -268,7 +268,7 @@ ModalComponent.reopenClass({
 
     let popoverService = container.lookup('service:popover');
 
-    popoverService.open(destinationElement, this, options);
+    return popoverService.open(destinationElement, this, options);
   }
 });
 

--- a/addon/components/modal-component.js
+++ b/addon/components/modal-component.js
@@ -242,22 +242,33 @@ var ModalComponent = Ember.Component.extend(
 ModalComponent.reopenClass({
   rootElement: '.ember-application',
   poppedModal: null,
-  hideAll: function() {
+  hideAll() {
     return $(document).trigger('modal:hide');
   },
-  popup: function(options) {
-    var modal, rootElement;
+  popup(options) {
     if (options == null) {
       options = {};
     }
     this.hideAll();
-    rootElement = options.rootElement || this.rootElement;
-    modal = this.create(options);
-    if (modal.get('targetObject.container')) {
-      modal.set('container', modal.get('targetObject.container'));
+
+    let rootElement = options.rootElement || this.rootElement;
+    let { container } = options;
+
+    if (!container) {
+      throw new Error(`<Subclass of ModalComponent>.popup() expects an option of {container}`);
     }
-    modal.appendTo(rootElement);
-    return modal;
+
+    let destinationElement = document.querySelector(rootElement);
+
+    if (!destinationElement) {
+      throw new Error(
+        '<Subclass of ModalComponent>.popup() expected the selector provided as {rootElement} to return a node currently on the page'
+      );
+    }
+
+    let popoverService = container.lookup('service:popover');
+
+    popoverService.open(destinationElement, this, options);
   }
 });
 

--- a/addon/components/modal-component.js
+++ b/addon/components/modal-component.js
@@ -182,28 +182,33 @@ var ModalComponent = Ember.Component.extend(
     }
   },
   hide: function() {
-    if (this.isDestroying) {
+    if (this.isDestroying || this.isDestroyed) {
       return;
     }
-    this.set('isShowing', false);
-    // bootstrap modal removes this class from the body when the modal closes
-    // to transfer scroll behavior back to the app
-    $(document.body).removeClass('modal-open');
-    if (this._backdrop) {
-      this._backdrop.removeClass('in');
-    }
-    if (this.get('fadeEnabled')) {
-      // destroy modal after backdroop faded out. We need to wrap this in a
-      // run-loop otherwise ember-testing will complain about auto run being
-      // disabled when we are in testing mode.
-      return this.$().one($.support.transition.end, (function(_this) {
-        return function() {
-          return Ember.run(_this, _this.destroy);
-        };
-      })(this));
-    } else {
-      return Ember.run(this, this.destroy);
-    }
+    Ember.run.join(() => {
+      this.set('isShowing', false);
+      // bootstrap modal removes this class from the body when the modal closes
+      // to transfer scroll behavior back to the app
+      $(document.body).removeClass('modal-open');
+      if (this._backdrop) {
+        this._backdrop.removeClass('in');
+      }
+      if (this.get('fadeEnabled')) {
+        // destroy modal after backdroop faded out. We need to wrap this in a
+        // run-loop otherwise ember-testing will complain about auto run being
+        // disabled when we are in testing mode.
+        this.$().one($.support.transition.end, () => {
+          Ember.run(() => {
+            if (this.isDestroyed) {
+              return;
+            }
+            this.closePopover ? this.closePopover() : this.destroy();
+          });
+        });
+      } else {
+        this.closePopover ? this.closePopover() : this.destroy();
+      }
+    });
   },
   _appendBackdrop: function() {
     var modalPaneBackdrop, parentLayer;

--- a/addon/components/popover-component.js
+++ b/addon/components/popover-component.js
@@ -28,14 +28,14 @@ PopoverComponent.reopenClass({
     let { container } = options;
 
     if (!container) {
-      throw new Error(`.popup() expects an option of {container}`);
+      throw new Error(`<Subclass of PopoverComponent>.popup() expects an option of {container}`);
     }
 
     let destinationElement = document.querySelector(rootElement);
 
     if (!destinationElement) {
       throw new Error(
-        '.popup() expected the selector provided as {rootElement} to return a node currently on the page'
+        '<Subclass of PopoverComponent>.popup() expected the selector provided as {rootElement} to return a node currently on the page'
       );
     }
 

--- a/addon/components/popover-component.js
+++ b/addon/components/popover-component.js
@@ -6,7 +6,7 @@ var PopoverComponent = Ember.Component.extend(PopoverMixin);
 
 PopoverComponent.reopenClass({
   rootElement: '.ember-application',
-  hideAll: function() {
+  hideAll() {
     return $(document).trigger('popover:hide');
   },
   /**
@@ -16,7 +16,7 @@ PopoverComponent.reopenClass({
    *    is shown. By default, it's set to true.
    */
 
-  popup: function(options, hideOthers) {
+  popup(options, hideOthers) {
     if (hideOthers == null) {
       hideOthers = true;
     }

--- a/addon/components/popover-component.js
+++ b/addon/components/popover-component.js
@@ -41,7 +41,7 @@ PopoverComponent.reopenClass({
 
     let popoverService = container.lookup('service:popover');
 
-    popoverService.open(destinationElement, this, options);
+    return popoverService.open(destinationElement, this, options);
   }
 });
 

--- a/addon/mixins/popover.js
+++ b/addon/mixins/popover.js
@@ -57,20 +57,23 @@ export default Ember.Mixin.create(StyleBindingsMixin, BodyEventListener, {
     if (this.isDestroyed) {
       return;
     }
-    this.set('isShowing', false);
 
-    if (this.get('fadeEnabled')) {
-      this.$().one($.support.transition.end, () => {
-        Ember.run(() => {
-          if (this.isDestroyed) {
-            return;
-          }
-          this.closePopover ? this.closePopover() : this.destroy();
+    Ember.run.join(() => {
+      this.set('isShowing', false);
+
+      if (this.get('fadeEnabled')) {
+        this.$().one($.support.transition.end, () => {
+          Ember.run(() => {
+            if (this.isDestroyed) {
+              return;
+            }
+            this.closePopover ? this.closePopover() : this.destroy();
+          });
         });
-      });
-    } else {
-      this.closePopover ? this.closePopover() : Ember.run(this, this.destroy);
-    }
+      } else {
+        this.closePopover ? this.closePopover() : this.destroy();
+      }
+    });
   },
   /*
   Calculate the offset of the given iframe relative to the top window.
@@ -240,8 +243,8 @@ export default Ember.Mixin.create(StyleBindingsMixin, BodyEventListener, {
     var _this = this;
     this._super();
     if (!this._hideHandler) {
-      this._hideHandler = function() {
-        return _this.hide();
+      this._hideHandler = () => {
+        this.hide();
       };
       $(document).on('popover:hide', this._hideHandler);
     }

--- a/addon/services/popover.js
+++ b/addon/services/popover.js
@@ -18,17 +18,20 @@ export default Ember.Service.extend({
       destinationElement
     };
 
-    options.closePopover = () => {
+    let closePopover = () => {
       this.popovers.removeObject(popoverSpec);
     };
 
     popoverSpec.childViews = [
       ComponentClass.create({
-        ...options
+        ...options,
+        closePopover
       })
     ];
 
     this.popovers.pushObject(popoverSpec);
+
+    return closePopover;
   },
 
   registerPopoverRendered() {

--- a/tests/dummy/app/routes/ember-widgets/modal.js
+++ b/tests/dummy/app/routes/ember-widgets/modal.js
@@ -4,16 +4,16 @@ import ModalComponent from 'ember-widgets/components/modal-component';
 
 export default Ember.Route.extend({
   actions: {
-    showModal: function() {
-      return ModalComponent.popup({
+    showModal() {
+      ModalComponent.popup({
         targetObject: this,
         confirm: "modalConfirm",
         cancel: "modalCancel",
         content: "Isn't this one fine day?"
       });
     },
-    showSmallModal: function() {
-      return ModalComponent.popup({
+    showSmallModal() {
+      ModalComponent.popup({
         targetObject: this,
         confirm: "modalConfirm",
         cancel: "modalCancel",
@@ -21,8 +21,8 @@ export default Ember.Route.extend({
         content: "This is quite small isn't it? You can also use 'large'."
       });
     },
-    showModalWithCustomContent: function() {
-      return ModalComponent.popup({
+    showModalWithCustomContent() {
+      ModalComponent.popup({
         targetObject: this,
         confirm: "modalConfirm",
         cancel: "modalCancel",
@@ -32,11 +32,11 @@ export default Ember.Route.extend({
         contentViewClass: CustomModalContentView
       });
     },
-    modalConfirm: function() {
-      return console.log("Modal Confirm!");
+    modalConfirm() {
+      console.log("Modal Confirm!");
     },
-    modalCancel: function() {
-      return console.log("Modal Cancel!");
+    modalCancel() {
+      console.log("Modal Cancel!");
     }
   }
 });

--- a/tests/dummy/app/templates/ember-widgets/-test-popover-content.hbs
+++ b/tests/dummy/app/templates/ember-widgets/-test-popover-content.hbs
@@ -1,0 +1,3 @@
+<div data-test-popover-content>
+  <button {{action 'fire'}} data-test-fire-action>Fire action</button>
+</div>

--- a/tests/integration/components/render-popover-test.js
+++ b/tests/integration/components/render-popover-test.js
@@ -2,6 +2,7 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 import PopoverComponent from 'ember-widgets/components/popover-component';
+import ModalComponent from 'ember-widgets/components/modal-component';
 
 moduleForComponent(
   'render-popover',
@@ -84,6 +85,95 @@ test('it handles event delegation in a popover', function(assert) {
 
   Ember.run(() => {
     TestPopoverComponent.popup({
+      container: this.container
+    });
+  });
+
+  assert.notOk(
+    hasHandledClick,
+    'precond - click event had not been handled'
+  );
+
+  $(document.querySelector('[data-test-popover-content]')).click();
+
+  assert.ok(
+    hasHandledClick,
+    'Clicke event handled'
+  );
+});
+
+test('it renders modals', function(assert) {
+  let TestModalComponent = ModalComponent.extend({
+    // From the dummy app
+    layoutName: 'ember-widgets/-test-popover-content'
+  });
+
+  this.render(hbs`{{render-popover}}`);
+
+  assert.ok(
+    document.querySelector('[data-test-popover-content]') === null,
+    'The modal is not rendered yet'
+  );
+
+  Ember.run(() => {
+    TestModalComponent.popup({
+      container: this.container
+    });
+  });
+
+  assert.ok(
+    document.querySelector('[data-test-popover-content]'),
+    'The modal is now rendered'
+  );
+});
+
+test('it handles actions in a modal', function(assert) {
+  let hasActionFired = false;
+  let TestModalComponent = ModalComponent.extend({
+    // From the dummy app
+    layoutName: 'ember-widgets/-test-popover-content',
+    actions: {
+      fire() {
+        hasActionFired = true;
+      }
+    }
+  });
+
+  this.render(hbs`{{render-popover}}`);
+
+  Ember.run(() => {
+    TestModalComponent.popup({
+      container: this.container
+    });
+  });
+
+  assert.notOk(
+    hasActionFired,
+    'precond - action has not fired'
+  );
+
+  $(document.querySelector('[data-test-fire-action]')).click();
+
+  assert.ok(
+    hasActionFired,
+    'Action was fired'
+  );
+});
+
+test('it handles event delegation in a popover', function(assert) {
+  let hasHandledClick = false;
+  let TestModalComponent = ModalComponent.extend({
+    // From the dummy app
+    layoutName: 'ember-widgets/-test-popover-content',
+    click() {
+      hasHandledClick = true;
+    }
+  });
+
+  this.render(hbs`{{render-popover}}`);
+
+  Ember.run(() => {
+    TestModalComponent.popup({
       container: this.container
     });
   });

--- a/tests/integration/components/render-popover-test.js
+++ b/tests/integration/components/render-popover-test.js
@@ -14,13 +14,13 @@ moduleForComponent(
 test('it renders popovers', function(assert) {
   let TestPopoverComponent = PopoverComponent.extend({
     // From the dummy app
-    layoutName: 'ember-widgets/popover'
+    layoutName: 'ember-widgets/-test-popover-content'
   });
 
   this.render(hbs`{{render-popover}}`);
 
   assert.ok(
-    document.querySelector('div.main-content-container') === null,
+    document.querySelector('[data-test-popover-content]') === null,
     'The popup is not rendered yet'
   );
 
@@ -32,7 +32,71 @@ test('it renders popovers', function(assert) {
 
   assert.ok(
     // Grab some random content from the template to make sure the popup was rendered
-    document.querySelector('div.main-content-container'),
+    document.querySelector('[data-test-popover-content]'),
     'The popup is now rendered'
+  );
+});
+
+test('it handles actions in a popover', function(assert) {
+  let hasActionFired = false;
+  let TestPopoverComponent = PopoverComponent.extend({
+    // From the dummy app
+    layoutName: 'ember-widgets/-test-popover-content',
+    actions: {
+      fire() {
+        hasActionFired = true;
+      }
+    }
+  });
+
+  this.render(hbs`{{render-popover}}`);
+
+  Ember.run(() => {
+    TestPopoverComponent.popup({
+      container: this.container
+    });
+  });
+
+  assert.notOk(
+    hasActionFired,
+    'precond - action has not fired'
+  );
+
+  $(document.querySelector('[data-test-fire-action]')).click();
+
+  assert.ok(
+    hasActionFired,
+    'Action was fired'
+  );
+});
+
+test('it handles event delegation in a popover', function(assert) {
+  let hasHandledClick = false;
+  let TestPopoverComponent = PopoverComponent.extend({
+    // From the dummy app
+    layoutName: 'ember-widgets/-test-popover-content',
+    click() {
+      hasHandledClick = true;
+    }
+  });
+
+  this.render(hbs`{{render-popover}}`);
+
+  Ember.run(() => {
+    TestPopoverComponent.popup({
+      container: this.container
+    });
+  });
+
+  assert.notOk(
+    hasHandledClick,
+    'precond - click event had not been handled'
+  );
+
+  $(document.querySelector('[data-test-popover-content]')).click();
+
+  assert.ok(
+    hasHandledClick,
+    'Clicke event handled'
   );
 });

--- a/tests/integration/components/render-popover-test.js
+++ b/tests/integration/components/render-popover-test.js
@@ -22,19 +22,24 @@ test('it renders popovers', function(assert) {
 
   assert.ok(
     document.querySelector('[data-test-popover-content]') === null,
-    'The popup is not rendered yet'
+    'The popover is not rendered yet'
   );
 
-  Ember.run(() => {
-    TestPopoverComponent.popup({
-      container: this.container
-    });
-  });
+  let close = Ember.run(() => TestPopoverComponent.popup({
+    container: this.container
+  }));
 
   assert.ok(
     // Grab some random content from the template to make sure the popup was rendered
     document.querySelector('[data-test-popover-content]'),
-    'The popup is now rendered'
+    'The popover is now rendered'
+  );
+
+  close();
+
+  assert.ok(
+    document.querySelector('[data-test-popover-content]') === null,
+    'The popover is closed'
   );
 });
 
@@ -115,15 +120,20 @@ test('it renders modals', function(assert) {
     'The modal is not rendered yet'
   );
 
-  Ember.run(() => {
-    TestModalComponent.popup({
-      container: this.container
-    });
-  });
+  let close = Ember.run(() => TestModalComponent.popup({
+    container: this.container
+  }));
 
   assert.ok(
     document.querySelector('[data-test-popover-content]'),
     'The modal is now rendered'
+  );
+
+  close();
+
+  assert.ok(
+    document.querySelector('[data-test-popover-content]') === null,
+    'The modal is closed'
   );
 });
 


### PR DESCRIPTION
In Ember 1.13 views instantiated via `create().appendTo()` do not have a view registry, and thus do not participate in event delegation (a `click() {` handler on a view/component).

This PR refactors the modal `popup(` method to use the `{{render-popover}}` based system for rendering. Included are tests for the new system using the modal base class and handling actions and events.