### PR TITLE
Correct re-export

### DIFF
--- a/app/components/carousel-item.js
+++ b/app/components/carousel-item.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-widgets/components/carousel-item';

--- a/app/views/carousel-item.js
+++ b/app/views/carousel-item.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-widgets/views/carousel-item';


### PR DESCRIPTION
There was a re-export file in `app/components/` that references a non-existent file in `addon/`. This replaces that file with another re-exporting from `app/views/` so that `{{#view 'carousel-item'}}` can be used downstream.