### PR TITLE
HTTP to HTTPS and remove target a-attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ember Widgets by Addepar [![Build Status](https://secure.travis-ci.org/Addepar/ember-widgets.svg?branch=master)](http://travis-ci.org/Addepar/ember-widgets)
+# Ember Widgets by Addepar [![Build Status](https://secure.travis-ci.org/Addepar/ember-widgets.svg?branch=master)](https://travis-ci.org/Addepar/ember-widgets)
 
 **THIS LIBRARY IS DEPRECATED**
 
@@ -8,7 +8,7 @@ set of Ember components.
 A collection of small widgets, easy to drop into place as Ember Components.
 
 ## Demo and Documentation
-http://addepar.github.com/ember-widgets/
+https://opensource.addepar.com/ember-widgets/
 
 ## Installation
 
@@ -30,4 +30,4 @@ http://addepar.github.com/ember-widgets/
 
 * `ember build`
 
-For more information on using ember-cli, visit [http://www.ember-cli.com/](http://www.ember-cli.com/).
+For more information on using ember-cli, visit [https://www.ember-cli.com/](https://www.ember-cli.com/).

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "@html-next/vertical-collection": "1.0.0-beta.10",
+    "@html-next/vertical-collection": "1.0.0-beta.12",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-less": "~1.3.1",

--- a/public/img/invalid_color.svg
+++ b/public/img/invalid_color.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 200 200" enable-background="new 0 0 200 200" xml:space="preserve">
 <rect x="-61" y="-33.4" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="322" height="266.8"/>
 <rect x="-143" y="93.7" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 241.4214 100)" fill="#D8D8DB" width="486" height="12.7"/>

--- a/public/img/invalid_color.svg
+++ b/public/img/invalid_color.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Icon" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" id="Icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 200 200" enable-background="new 0 0 200 200" xml:space="preserve">
 <rect x="-61" y="-33.4" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="322" height="266.8"/>
 <rect x="-143" y="93.7" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 241.4214 100)" fill="#D8D8DB" width="486" height="12.7"/>

--- a/public/img/no_color.svg
+++ b/public/img/no_color.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Icon" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" id="Icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <rect x="-30.5" y="-16.7" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="161" height="133.4"/>
 <rect x="-71.5" y="46.8" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -20.7031 49.9828)" fill="#A80000" width="243" height="6.3"/>

--- a/public/img/no_color.svg
+++ b/public/img/no_color.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <rect x="-30.5" y="-16.7" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="161" height="133.4"/>
 <rect x="-71.5" y="46.8" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -20.7031 49.9828)" fill="#A80000" width="243" height="6.3"/>

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,7 +9,7 @@
 
     {{content-for "head"}}
     <!-- Load Fonts from Fonts.com -->
-    <link type="text/css" rel="stylesheet" href="http://fast.fonts.net/cssapi/cc61a2f8-3c32-45ef-9be7-fc0cc1fab22b.css"/>
+    <link type="text/css" rel="stylesheet" href="https://fast.fonts.net/cssapi/cc61a2f8-3c32-45ef-9be7-fc0cc1fab22b.css"/>
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">

--- a/tests/dummy/app/templates/_footer.hbs
+++ b/tests/dummy/app/templates/_footer.hbs
@@ -23,23 +23,23 @@
       <div class="col-md-3">
         <ul class="list-unstyled">
           <li><h6>Addepar Open Source</h6></li>
-          <li><a target="_BLANK" href="http://addepar.github.io/">Home</a></li>
+          <li><a href="https://addepar.github.io/">Home</a></li>
           <li>{{#link-to 'license'}}License{{/link-to}}</li>
         </ul>
       </div>
       <div class="col-md-3">
         <ul class="list-unstyled">
           <li><h6>About Addepar</h6></li>
-          <li><a target="_BLANK" href="http://www.addepar.com">www.addepar.com</a></li>
+          <li><a href="https://www.addepar.com">www.addepar.com</a></li>
           <li>
             <address>
               <br>
-              <a target="_BLANK" href="http://goo.gl/maps/446ui"><strong>Addepar HQ</strong><br>
-              1215 Terra Bella Ave<br>
-              Mountain View, CA 94043</a><br><br>
+              <a href="https://www.google.com/maps/dir//303+Bryant+Street+Mountain+View,+CA+94041"><strong>Addepar MV</strong><br>
+              303 Bryant Street<br>
+              Mountain View, CA 94041</a><br><br>
 
-              <a target="_BLANK" href="http://goo.gl/maps/xEiCM"><strong>Addepar NY</strong><br>
-              335 Madison Ave Suite 880<br>
+              <a href="https://www.google.com/maps/dir//335+Madison+Ave+%231430,+New+York,+NY+10017"><strong>Addepar NY</strong><br>
+              335 Madison Ave, Suite 1430<br>
               New York, NY 10017</a><br>
             </address>
           </li>
@@ -48,7 +48,7 @@
     </div>
     <div class="row">
       <div class="col-md-12 center-align">
-        <p>&copy; 2013 Addepar, Inc.</p>
+        <p>&copy; 2018 Addepar, Inc.</p>
       </div>
     </div>
   </div>

--- a/tests/dummy/app/templates/_navigation.hbs
+++ b/tests/dummy/app/templates/_navigation.hbs
@@ -7,15 +7,15 @@
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
     </button>
-    <a class="navbar-brand" href="http://addepar.github.io/">
+    <a class="navbar-brand" href="https://addepar.github.io/">
       <img id="logo_dark" class="logo" src="img/addepar_logo_light.png" /><span class="navbar-title">Open Source</span>
     </a>
   </div>
 
   <div class="collapse navbar-collapse navbar-ex1-collapse">
     <ul class="nav navbar-nav navbar-right">
-      <li><a href="http://addepar.github.io/ember-table">Ember Table</a></li>
-      <li><a href="http://addepar.github.io/ember-charts">Ember Charts</a></li>
+      <li><a href="https://addepar.github.io/ember-table">Ember Table</a></li>
+      <li><a href="https://addepar.github.io/ember-charts">Ember Charts</a></li>
       <li><a href="#">Ember Widgets</a></li>
     </ul>
   </div><!-- /.navbar-collapse -->

--- a/tests/dummy/app/templates/ember-widgets/-sub-navigation.hbs
+++ b/tests/dummy/app/templates/ember-widgets/-sub-navigation.hbs
@@ -7,7 +7,7 @@
       </a>
     </li>
     <li>
-      <iframe src="http://ghbtns.com/github-btn.html?user=addepar&amp;repo=ember-widgets&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="130" height="30"></iframe>
+      <iframe src="https://ghbtns.com/github-btn.html?user=addepar&amp;repo=ember-widgets&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="130" height="30"></iframe>
     </li>
   </ul>
   <hr>

--- a/tests/dummy/app/templates/ember-widgets/modal.hbs
+++ b/tests/dummy/app/templates/ember-widgets/modal.hbs
@@ -7,7 +7,7 @@ component which overlays the page. Typically, modals are pre-rendered
 into the page, even before they are needed. Our approach appends the
 modal when it is required and removes it once it is no longer visible.
 We designed it such that actions are sent to the application the same way <a
-href="http://emberjs.com/guides/components/sending-actions-from-components-to-your-application/">components
+href="https://emberjs.com/guides/components/sending-actions-from-components-to-your-application/">components
 send them.</a> One caveat is that we need to pass in the current
 controller as the target object to receive actions and to inherit the
 container.</p>

--- a/tests/dummy/app/templates/ember-widgets/overview.hbs
+++ b/tests/dummy/app/templates/ember-widgets/overview.hbs
@@ -4,7 +4,7 @@
     <div class="col-md-12">
       <h1>Ember Widgets</h1>
       <p class="elevated">A component library built with the <a
-        target="_BLANK" href="http://emberjs.com/">Ember.js</a>
+        href="https://emberjs.com/">Ember.js</a>
       framework. Includes easy to extend components such as select,
       popover, modal, carousel, and accordion. This library is built on
       bootstrap 3.0 CSS and represents our ideas about component best
@@ -27,11 +27,11 @@
     <div class="col-md-6">
       <h3>Dependencies</h3>
       <ul class="styled">
-        <li><a target="_BLANK" href="http://emberjs.com/">Ember.js</a></li>
-        <li><a target="_BLANK" href="https://github.com/html-next/vertical-collection">vertical-collection</a></li>
-        <li><a target="_BLANK" href="http://getbootstrap.com/">Bootstrap (V3)</a></li>
-        <li><a target="_BLANK" href="http://lodash.com/">Lo-Dash</a></li>
-        <li><a target="_BLANK" href="http://jquery.com/">jQuery</a></li>
+        <li><a href="https://emberjs.com/">Ember.js</a></li>
+        <li><a href="https://github.com/html-next/vertical-collection">vertical-collection</a></li>
+        <li><a href="https://getbootstrap.com/">Bootstrap (V3)</a></li>
+        <li><a href="https://lodash.com/">Lo-Dash</a></li>
+        <li><a href="https://jquery.com/">jQuery</a></li>
       </ul>
     </div>
   </div>
@@ -74,8 +74,8 @@
     <div class="col-md-6">
       <hr>
       <h1>Getting Started</h1>
-      <p>You will need <a target="_BLANK" href="http://nodejs.org/">node</a> installed as a development dependency.</p>
-      <p><a target="_BLANK" href="https://github.com/Addepar/ember-widgets/">Clone it from Github</a> or <a target="_BLANK" href="https://github.com/Addepar/ember-widgets/releases">download the ZIP repo</a></p>
+      <p>You will need <a href="https://nodejs.org/">node</a> installed as a development dependency.</p>
+      <p><a href="https://github.com/Addepar/ember-widgets/">Clone it from Github</a> or <a href="https://github.com/Addepar/ember-widgets/releases">download the ZIP repo</a></p>
       <div class="highlight">
 <pre><code>$ npm install -g grunt-cli
 $ npm install

--- a/tests/dummy/app/templates/ember-widgets/select.hbs
+++ b/tests/dummy/app/templates/ember-widgets/select.hbs
@@ -1,6 +1,6 @@
 <div class="col-md-10 col-md-offset-2 left-border main-content-container">
   <h2>Select <small> Ember.Widgets.Select</small></h2>
-  <p class="elevated">Ember select is a Ember.js based replacement for select boxes. It supports searching, remote data sets, and infinite scrolling of results. This component&#39;s design was inspired by the excellent <a target="_BLANK" href="http://harvesthq.github.io/chosen/">Chosen</a> jquery plugin and <a target="_BLANK" href="http://ivaynberg.github.io/select2/">Select2</a>. Uses the <a target="_BLANK" href="https://github.com/html-next/vertical-collection">vertical-collection</a> for lazily rendering large arrays of content.</p>
+  <p class="elevated">Ember select is a Ember.js based replacement for select boxes. It supports searching, remote data sets, and infinite scrolling of results. This component&#39;s design was inspired by the excellent <a href="https://harvesthq.github.io/chosen/">Chosen</a> jquery plugin and <a href="https://ivaynberg.github.io/select2/">Select2</a>. Uses the <a target="_BLANK" href="https://github.com/html-next/vertical-collection">vertical-collection</a> for lazily rendering large arrays of content.</p>
 
   <div class="row">
     <div class="col-md-6">

--- a/tests/dummy/public/crossdomain.xml
+++ b/tests/dummy/public/crossdomain.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
+<!DOCTYPE cross-domain-policy SYSTEM "https://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
   <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
 

--- a/tests/dummy/public/img/invalid_color.svg
+++ b/tests/dummy/public/img/invalid_color.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 200 200" enable-background="new 0 0 200 200" xml:space="preserve">
 <rect x="-61" y="-33.4" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="322" height="266.8"/>
 <rect x="-143" y="93.7" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 241.4214 100)" fill="#D8D8DB" width="486" height="12.7"/>

--- a/tests/dummy/public/img/invalid_color.svg
+++ b/tests/dummy/public/img/invalid_color.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Icon" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" id="Icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 200 200" enable-background="new 0 0 200 200" xml:space="preserve">
 <rect x="-61" y="-33.4" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="322" height="266.8"/>
 <rect x="-143" y="93.7" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 241.4214 100)" fill="#D8D8DB" width="486" height="12.7"/>

--- a/tests/dummy/public/img/no_color.svg
+++ b/tests/dummy/public/img/no_color.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Icon" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" id="Icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <rect x="-30.5" y="-16.7" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="161" height="133.4"/>
 <rect x="-71.5" y="46.8" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -20.7031 49.9828)" fill="#A80000" width="243" height="6.3"/>

--- a/tests/dummy/public/img/no_color.svg
+++ b/tests/dummy/public/img/no_color.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Icon" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <rect x="-30.5" y="-16.7" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="161" height="133.4"/>
 <rect x="-71.5" y="46.8" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -20.7031 49.9828)" fill="#A80000" width="243" height="6.3"/>


### PR DESCRIPTION
Target a-attributes are removed to prevent phishing: https://dev.to/ben/the-targetblank-vulnerability-by-example

Also update @html-next/vertical-collection to fix a build issue.