### PR TITLE
Test highlights. Clean up highlights logic.

### DIFF
--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -444,12 +444,18 @@ export default Ember.Component.extend(
     }
     return this.set('selection', content.findProperty(defaultPath));
   }, 'content.[]'),
+
   selectableOptionsDidChange: Ember.observer(function() {
-    var highlighted;
+    /*
+     * If the dropdown is visible and the selected option is no longer
+     * contained in the list of selectableOptions, then force the first
+     * selectableOption to be highlighted.
+     */
     if (this.get('showDropdown')) {
-      highlighted = this.get('highlighted');
-      if (!this.get('selectableOptions').contains(highlighted)) {
-        return this.set('highlighted', this.get('selectableOptions.firstObject'));
+      let highlighted = this.get('highlighted');
+      let selectableOptions = this.get('selectableOptions');
+      if (!selectableOptions.contains(highlighted)) {
+        this.set('highlighted', selectableOptions.get('firstObject'));
       }
     }
   }, 'selectableOptions.[]', 'showDropdown'),
@@ -482,17 +488,21 @@ export default Ember.Component.extend(
 
   // The option that is currently highlighted.
   highlighted: Ember.computed(function(key, value) {
-    var content, index;
-    content = this.get('selectableOptions') || Ember.A();
-    value = value || Ember.A();
+    let content = this.get('selectableOptions') || Ember.A();
+
     if (arguments.length === 1) {
-      index = this.get('highlightedIndex');
-      value = content.objectAt(index);
-    } else {
-      index = content.indexOf(value);
-      this.setHighlightedIndex(index, this.get('shouldEnsureVisible'));
+      // Getter
+      return content.objectAt(this.get('highlightedIndex'));
     }
-    return value;
+    
+    // Setter
+    let index = value ? content.indexOf(value) : -1;
+    this.setHighlightedIndex(
+      index,
+      this.get('shouldEnsureVisible')
+    );
+    return value || [];
+
   }).property('selectableOptions.[]', 'highlightedIndex', 'shouldEnsureVisible'),
 
   setFocus: function() {

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -149,6 +149,81 @@ test('Test keyboard interaction', function(assert) {
   });
 });
 
+test('Test query highlighting', function(assert) {
+  select = this.subject({
+    content: ['aaa', 'bar', 'barca', 'baz']
+  });
+  this.append();
+  let selectComponent = select.$();
+  selectComponent.focus();
+
+  andThen(() => {
+    pressEnter(selectComponent);
+  });
+
+  andThen(() => {
+    assert.ok(
+      isVisible('.ember-select-results', selectComponent),
+      'Dropdown list should appear after pressing Enter'
+    );
+    let resultItems = find('.ember-select-result-item', selectComponent);
+    assert.ok(
+      resultItems[0].classList.contains('highlighted'),
+      'First option should be highlighted'
+    );
+    assert.equal(
+      resultItems.length,
+      4,
+      'All options visible'
+    );
+    assert.equal(
+      resultItems[0].innerText,
+      'aaa',
+      'First option should be the first content'
+    );
+  });
+
+  fillIn($('input', selectComponent)[0], 'b');
+
+  andThen(() => {
+    let resultItems = find('.ember-select-result-item', selectComponent);
+    assert.ok(
+      resultItems[0].classList.contains('highlighted'),
+      'First option should be highlighted'
+    );
+    assert.equal(
+      resultItems.length,
+      3,
+      'Matching options visible'
+    );
+    assert.equal(
+      resultItems[0].innerText,
+      'bar',
+      'First option should be the first matching content'
+    );
+
+    select.set('content', ['a1', 'b1', 'b2']);
+  });
+
+  andThen(() => {
+    let resultItems = find('.ember-select-result-item', selectComponent);
+    assert.ok(
+      resultItems[0].classList.contains('highlighted'),
+      'First option should be highlighted'
+    );
+    assert.equal(
+      resultItems.length,
+      2,
+      'Matching options visible'
+    );
+    assert.equal(
+      resultItems[0].innerText,
+      'b1',
+      'First option should be the first matching content'
+    );
+  });
+});
+
 test('Test userSelected action', function(assert) {
   var selectElement, spy;
   assert.expect(3);


### PR DESCRIPTION
~In usage with 1.13 the observer which sets the first selectable item as highlighted does not always run after the selectableOptions value has been updated. This addresses the timing issue by ensuring the observer work occurs after bindings flush.~

~Frustratingly this test does not seem to reproduce the issue (though it is nice to add anyway). In downstream usage we have another test that is resolved by the observer timing change.~

After looking further at how this fix integrates with the downstream consumer I think it is too invasive. That said, the test and code cleanup here are valid and tested against the downstream consumer, so IMO this is good to go.