### PR TITLE
Pass the modalComponent when invoking contentView

### DIFF
--- a/app/templates/modal.hbs
+++ b/app/templates/modal.hbs
@@ -4,7 +4,7 @@
       {{view _headerViewClass}}
     </div>
     <div class="modal-body {{bodyClass}}">
-      {{view _contentViewClass}}
+      {{view _contentViewClass modalComponent=this}}
     </div>
     <div class="modal-footer {{footerClass}}">
       {{view _footerViewClass}}


### PR DESCRIPTION
A template rendered by a modal may require access to the modal instance itself. In some historical cases this could have been worked around by accessing `parentController`, but as we refactor to components and later versions of Ember that property is no longer always available or stable.