### PR TITLE
Fix a race condition between value/content

### DIFF
--- a/tests/unit/components/select-component-test.js
+++ b/tests/unit/components/select-component-test.js
@@ -311,3 +311,58 @@ test('optionValuePath with nested valuePath', function(assert) {
   });
   assert.equal(obj2, select.get('selection'), 'The right selection is retrieved');
 });
+
+test('selection, based on value, should be updated after content is set', function(assert) {
+  select = this.subject({
+    optionValuePath: 'valueProp',
+    value: 'initial'
+  });
+
+  assert.equal(undefined, select.get('selection'), 'precond - selection is undefined');
+
+  let selectionFromContent = { valueProp: 'initial' };
+  Ember.run(function() {
+    select.set('content', [
+      selectionFromContent
+    ]);
+  });
+
+  assert.equal(selectionFromContent, select.get('selection'), 'selection was updated after content was set');
+});
+
+test('value, based on selection, should be updated after content is set', function(assert) {
+  let selection = { valueProp: 'initial' };
+  select = this.subject({
+    optionValuePath: 'valueProp',
+    selection
+  });
+
+  assert.equal('initial', select.get('value'), 'precond - value is undefined');
+
+  Ember.run(function() {
+    select.set('content', [
+      selection
+    ]);
+  });
+
+  assert.equal(selection.valueProp, select.get('value'), 'value was updated after content was set');
+});
+
+test('selection, based on null value, should be updated after content is set', function(assert) {
+  select = this.subject({
+    optionValuePath: 'valueProp',
+    value: null
+  });
+
+  assert.equal(undefined, select.get('selection'), 'precond - selection is undefined');
+
+  let selectionFromContent = { valueProp: null };
+  Ember.run(function() {
+    select.set('content', [
+      selectionFromContent
+    ]);
+  });
+
+  assert.equal(selectionFromContent, select.get('selection'), 'selection was updated after content was set');
+  assert.equal(null, select.get('value'), 'value still null after content was set');
+});


### PR DESCRIPTION
Previously if a value argument was set before content had been set (which may happen during initialization) then a selection value would be set matching the value. This selection would probably be wrong, especially if `optionValuePath` is also present, meaning selection is expected to be an object.

This refactors some of the current implementation to make clearer what the code intent is, and makes these changes:

* Rename setDefaultSelection to updateSelectionFromContent, and include logic that skips the work during initialization and propagated the value -> selection if needed.
* Move updateSelectionFromContent into `init` instead of `didInsertElement`. This work just needs to happen after arguments, not after rendering itself.
* Add tests that show value -> selection and selection -> value being honored when the content property changes.