### PR TITLE
Close popups in capture phase

### DIFF
--- a/addon/mixins/body-event-listener.js
+++ b/addon/mixins/body-event-listener.js
@@ -41,11 +41,11 @@ export default Ember.Mixin.create({
       });
     };
 
-    return $(this.get('bodyElementSelector')).on("click", this._clickHandler);
+    $(this.get('bodyElementSelector')).get(0).addEventListener("click", this._clickHandler, {capture: true});
   },
   _removeDocumentHandlers: function() {
     if (this._clickHandler) {
-      $(this.get('bodyElementSelector')).off("click", this._clickHandler);
+      $(this.get('bodyElementSelector')).get(0).removeEventListener("click", this._clickHandler, {capture: true});
     }
     return this._clickHandler = null;
   }


### PR DESCRIPTION
Popups were handling click events after the logic for the page had run. This meant sometimes you clicked on part of the page, Ember might re-render that part of the page and remove the click target, and *then* the closing logic here would run.

The closing logic confirms that the click target is still on the page, but as mentioned above the click target may not be.

Options here would be to remove the check for the target being on the page, or to handle closing the popovers on capture phase before other logic related to the click happens. I think that is the most appropriate solution, and so implemented it here.