### PR TITLE
Close popups in mousedown

### DIFF
--- a/addon/mixins/body-event-listener.js
+++ b/addon/mixins/body-event-listener.js
@@ -41,11 +41,11 @@ export default Ember.Mixin.create({
       });
     };
 
-    return $(this.get('bodyElementSelector')).on("click", this._clickHandler);
+    $(this.get('bodyElementSelector')).on("mousedown", this._clickHandler);
   },
   _removeDocumentHandlers: function() {
     if (this._clickHandler) {
-      $(this.get('bodyElementSelector')).off("click", this._clickHandler);
+      $(this.get('bodyElementSelector')).off("mousedown", this._clickHandler);
     }
     return this._clickHandler = null;
   }

--- a/tests/integration/color-picker-test.js
+++ b/tests/integration/color-picker-test.js
@@ -151,8 +151,8 @@ test('Click outside of the component should close the dropdown', function(assert
   colorPicker = this.subject();
   this.append();
   openColorChooser();
+  click($('body').get(0));
   return andThen(function() {
-    $('body').trigger('click');
     return assert.ok(isNotPresent(getColorPickerDropdown()), 'The dropdown should disappear when clicking outside');
   });
 });


### PR DESCRIPTION
Popups were handling click events after the logic for the page had run. This meant sometimes you clicked on part of the page, Ember might re-render that part of the page and remove the click target, and *then* the closing logic here would run.

The closing logic confirms that the click target is still on the page, but as mentioned above the click target may not be.

Options here would be to remove the check for the target being on the page, or to handle closing the popovers on capture phase before other logic related to the click happens, or to use a psuedo-before-click event like mousedown.

Removing the check may cause some unexpected new behaviors so I would like to avoid it. Using the capture phase is a big change for this library since it then would not be testable via jQuery's click even triggering.

So using the psuedo-before-click handler of mousedown seems good. This is not compatible with some kinds of non-mouse input, which is the main risk of this approach.

Replaces: https://github.com/Addepar/ember-widgets/pull/284