### PR TITLE
WIP: Close popups in without checking target attachment

### DIFF
--- a/addon/mixins/body-event-listener.js
+++ b/addon/mixins/body-event-listener.js
@@ -24,24 +24,19 @@ export default Ember.Mixin.create({
     }
 
     this._clickHandler = function(event) {
-      return Ember.run(function() {
+      Ember.run(function() {
         if ((_this.get('_state') || _this.get('state')) === 'inDOM' && Ember.isEmpty(_this.$().has($(event.target)))) {
-          // check if event.target still exists in DOM
-          var checkContain = $.contains(document.body, event.target);
-          var isBodyElement = event.target === document.body;
-          if (checkContain || isBodyElement) {
-            // bodyClick starts taking parameter "event" to make room to control
-            // some special cases where there is a component added to the body
-            // instead of the app (such as bootstrap date-picker).
-            // If it is the case, we can check for the event target to prevent
-            // the popover from being closed.
-            return _this.bodyClick(event);
-          }
+          // bodyClick starts taking parameter "event" to make room to control
+          // some special cases where there is a component added to the body
+          // instead of the app (such as bootstrap date-picker).
+          // If it is the case, we can check for the event target to prevent
+          // the popover from being closed.
+          _this.bodyClick(event);
         }
       });
     };
 
-    return $(this.get('bodyElementSelector')).on("click", this._clickHandler);
+    $(this.get('bodyElementSelector')).on("click", this._clickHandler);
   },
   _removeDocumentHandlers: function() {
     if (this._clickHandler) {

--- a/tests/integration/color-picker-test.js
+++ b/tests/integration/color-picker-test.js
@@ -151,8 +151,8 @@ test('Click outside of the component should close the dropdown', function(assert
   colorPicker = this.subject();
   this.append();
   openColorChooser();
+  click($('body').get(0));
   return andThen(function() {
-    $('body').trigger('click');
     return assert.ok(isNotPresent(getColorPickerDropdown()), 'The dropdown should disappear when clicking outside');
   });
 });


### PR DESCRIPTION
Popups are handling click events after the logic for the page has rendered. This means sometimes you click on part of the page, Ember might re-render that part of the page and remove the click target, and *then* the closing logic in body-event-listener will run.

The closing logic confirmed that the click target is still on the page, but as mentioned above the click target may not be. It isn't clear why this logic exists in the first place.

Options to rationalize this: Remove the check for the target being on the page, or handle closing the popovers on capture phase before other logic related to the click happens, or use a psuedo-before-click event like mousedown.

Here the check is simply removed, meaning clicking on something outside the box will always cause a popover to be destroyed regardless of the target's attachment state.

References:

* https://github.com/Addepar/ember-widgets/pull/285
* https://github.com/Addepar/ember-widgets/pull/284