### PR TITLE
Add example in documentation of `select-component` to show grouped options

### DIFF
--- a/tests/dummy/app/data/countries.js
+++ b/tests/dummy/app/data/countries.js
@@ -2,247 +2,1219 @@ import Ember from 'ember';
 
 // The view for each item in the select.
 export default Ember.A([
-    {name: 'Afghanistan', code: 'AF'},
-    {name: 'Aland Islands', code: 'AX'},
-    {name: 'Albania', code: 'AL'},
-    {name: 'Algeria', code: 'DZ'},
-    {name: 'American Samoa', code: 'AS'},
-    {name: 'Andorra', code: 'AD'},
-    {name: 'Angola', code: 'AO'},
-    {name: 'Anguilla', code: 'AI'},
-    {name: 'Antarctica', code: 'AQ'},
-    {name: 'Antigua and Barbuda', code: 'AG'},
-    {name: 'Argentina', code: 'AR'},
-    {name: 'Armenia', code: 'AM'},
-    {name: 'Aruba', code: 'AW'},
-    {name: 'Australia', code: 'AU'},
-    {name: 'Austria', code: 'AT'},
-    {name: 'Azerbaijan', code: 'AZ'},
-    {name: 'Bahamas', code: 'BS'},
-    {name: 'Bahrain', code: 'BH'},
-    {name: 'Bangladesh', code: 'BD'},
-    {name: 'Barbados', code: 'BB'},
-    {name: 'Belarus', code: 'BY'},
-    {name: 'Belgium', code: 'BE'},
-    {name: 'Belize', code: 'BZ'},
-    {name: 'Benin', code: 'BJ'},
-    {name: 'Bermuda', code: 'BM'},
-    {name: 'Bhutan', code: 'BT'},
-    {name: 'Bolivia', code: 'BO'},
-    {name: 'Bosnia and Herzegovina', code: 'BA'},
-    {name: 'Botswana', code: 'BW'},
-    {name: 'Bouvet Island', code: 'BV'},
-    {name: 'Brazil', code: 'BR'},
-    {name: 'British Indian Ocean Territory', code: 'IO'},
-    {name: 'Brunei Darussalam', code: 'BN'},
-    {name: 'Bulgaria', code: 'BG'},
-    {name: 'Burkina Faso', code: 'BF'},
-    {name: 'Burundi', code: 'BI'},
-    {name: 'Cambodia', code: 'KH'},
-    {name: 'Cameroon', code: 'CM'},
-    {name: 'Canada', code: 'CA'},
-    {name: 'Cape Verde', code: 'CV'},
-    {name: 'Cayman Islands', code: 'KY'},
-    {name: 'Central African Republic', code: 'CF'},
-    {name: 'Chad', code: 'TD'},
-    {name: 'Chile', code: 'CL'},
-    {name: 'China', code: 'CN'},
-    {name: 'Christmas Island', code: 'CX'},
-    {name: 'Cocos (Keeling) Islands', code: 'CC'},
-    {name: 'Colombia', code: 'CO'},
-    {name: 'Comoros', code: 'KM'},
-    {name: 'Congo', code: 'CG'},
-    {name: 'Congo, The Democratic Republic of the', code: 'CD'},
-    {name: 'Cook Islands', code: 'CK'},
-    {name: 'Costa Rica', code: 'CR'},
-    {name: 'Cote D\'Ivoire', code: 'CI'},
-    {name: 'Croatia', code: 'HR'},
-    {name: 'Cuba', code: 'CU'},
-    {name: 'Cyprus', code: 'CY'},
-    {name: 'Czech Republic', code: 'CZ'},
-    {name: 'Denmark', code: 'DK'},
-    {name: 'Djibouti', code: 'DJ'},
-    {name: 'Dominica', code: 'DM'},
-    {name: 'Dominican Republic', code: 'DO'},
-    {name: 'Ecuador', code: 'EC'},
-    {name: 'Egypt', code: 'EG'},
-    {name: 'El Salvador', code: 'SV'},
-    {name: 'Equatorial Guinea', code: 'GQ'},
-    {name: 'Eritrea', code: 'ER'},
-    {name: 'Estonia', code: 'EE'},
-    {name: 'Ethiopia', code: 'ET'},
-    {name: 'Falkland Islands (Malvinas)', code: 'FK'},
-    {name: 'Faroe Islands', code: 'FO'},
-    {name: 'Fiji', code: 'FJ'},
-    {name: 'Finland', code: 'FI'},
-    {name: 'France', code: 'FR'},
-    {name: 'French Guiana', code: 'GF'},
-    {name: 'French Polynesia', code: 'PF'},
-    {name: 'French Southern Territories', code: 'TF'},
-    {name: 'Gabon', code: 'GA'},
-    {name: 'Gambia', code: 'GM'},
-    {name: 'Georgia', code: 'GE'},
-    {name: 'Germany', code: 'DE'},
-    {name: 'Ghana', code: 'GH'},
-    {name: 'Gibraltar', code: 'GI'},
-    {name: 'Greece', code: 'GR'},
-    {name: 'Greenland', code: 'GL'},
-    {name: 'Grenada', code: 'GD'},
-    {name: 'Guadeloupe', code: 'GP'},
-    {name: 'Guam', code: 'GU'},
-    {name: 'Guatemala', code: 'GT'},
-    {name: 'Guernsey', code: 'GG'},
-    {name: 'Guinea', code: 'GN'},
-    {name: 'Guinea-Bissau', code: 'GW'},
-    {name: 'Guyana', code: 'GY'},
-    {name: 'Haiti', code: 'HT'},
-    {name: 'Heard Island and Mcdonald Islands', code: 'HM'},
-    {name: 'Holy See (Vatican City State)', code: 'VA'},
-    {name: 'Honduras', code: 'HN'},
-    {name: 'Hong Kong', code: 'HK'},
-    {name: 'Hungary', code: 'HU'},
-    {name: 'Iceland', code: 'IS'},
-    {name: 'India', code: 'IN'},
-    {name: 'Indonesia', code: 'ID'},
-    {name: 'Iran, Islamic Republic Of', code: 'IR'},
-    {name: 'Iraq', code: 'IQ'},
-    {name: 'Ireland', code: 'IE'},
-    {name: 'Isle of Man', code: 'IM'},
-    {name: 'Israel', code: 'IL'},
-    {name: 'Italy', code: 'IT'},
-    {name: 'Jamaica', code: 'JM'},
-    {name: 'Japan', code: 'JP'},
-    {name: 'Jersey', code: 'JE'},
-    {name: 'Jordan', code: 'JO'},
-    {name: 'Kazakhstan', code: 'KZ'},
-    {name: 'Kenya', code: 'KE'},
-    {name: 'Kiribati', code: 'KI'},
-    {name: 'Korea, Democratic People\'S Republic of', code: 'KP'},
-    {name: 'Korea, Republic of', code: 'KR'},
-    {name: 'Kuwait', code: 'KW'},
-    {name: 'Kyrgyzstan', code: 'KG'},
-    {name: 'Lao People\'S Democratic Republic', code: 'LA'},
-    {name: 'Latvia', code: 'LV'},
-    {name: 'Lebanon', code: 'LB'},
-    {name: 'Lesotho', code: 'LS'},
-    {name: 'Liberia', code: 'LR'},
-    {name: 'Libyan Arab Jamahiriya', code: 'LY'},
-    {name: 'Liechtenstein', code: 'LI'},
-    {name: 'Lithuania', code: 'LT'},
-    {name: 'Luxembourg', code: 'LU'},
-    {name: 'Macao', code: 'MO'},
-    {name: 'Macedonia, The Former Yugoslav Republic of', code: 'MK'},
-    {name: 'Madagascar', code: 'MG'},
-    {name: 'Malawi', code: 'MW'},
-    {name: 'Malaysia', code: 'MY'},
-    {name: 'Maldives', code: 'MV'},
-    {name: 'Mali', code: 'ML'},
-    {name: 'Malta', code: 'MT'},
-    {name: 'Marshall Islands', code: 'MH'},
-    {name: 'Martinique', code: 'MQ'},
-    {name: 'Mauritania', code: 'MR'},
-    {name: 'Mauritius', code: 'MU'},
-    {name: 'Mayotte', code: 'YT'},
-    {name: 'Mexico', code: 'MX'},
-    {name: 'Micronesia, Federated States of', code: 'FM'},
-    {name: 'Moldova, Republic of', code: 'MD'},
-    {name: 'Monaco', code: 'MC'},
-    {name: 'Mongolia', code: 'MN'},
-    {name: 'Montserrat', code: 'MS'},
-    {name: 'Morocco', code: 'MA'},
-    {name: 'Mozambique', code: 'MZ'},
-    {name: 'Myanmar', code: 'MM'},
-    {name: 'Namibia', code: 'NA'},
-    {name: 'Nauru', code: 'NR'},
-    {name: 'Nepal', code: 'NP'},
-    {name: 'Netherlands', code: 'NL'},
-    {name: 'Netherlands Antilles', code: 'AN'},
-    {name: 'New Caledonia', code: 'NC'},
-    {name: 'New Zealand', code: 'NZ'},
-    {name: 'Nicaragua', code: 'NI'},
-    {name: 'Niger', code: 'NE'},
-    {name: 'Nigeria', code: 'NG'},
-    {name: 'Niue', code: 'NU'},
-    {name: 'Norfolk Island', code: 'NF'},
-    {name: 'Northern Mariana Islands', code: 'MP'},
-    {name: 'Norway', code: 'NO'},
-    {name: 'Oman', code: 'OM'},
-    {name: 'Pakistan', code: 'PK'},
-    {name: 'Palau', code: 'PW'},
-    {name: 'Palestinian Territory, Occupied', code: 'PS'},
-    {name: 'Panama', code: 'PA'},
-    {name: 'Papua New Guinea', code: 'PG'},
-    {name: 'Paraguay', code: 'PY'},
-    {name: 'Peru', code: 'PE'},
-    {name: 'Philippines', code: 'PH'},
-    {name: 'Pitcairn', code: 'PN'},
-    {name: 'Poland', code: 'PL'},
-    {name: 'Portugal', code: 'PT'},
-    {name: 'Puerto Rico', code: 'PR'},
-    {name: 'Qatar', code: 'QA'},
-    {name: 'Reunion', code: 'RE'},
-    {name: 'Romania', code: 'RO'},
-    {name: 'Russian Federation', code: 'RU'},
-    {name: 'RWANDA', code: 'RW'},
-    {name: 'Saint Helena', code: 'SH'},
-    {name: 'Saint Kitts and Nevis', code: 'KN'},
-    {name: 'Saint Lucia', code: 'LC'},
-    {name: 'Saint Pierre and Miquelon', code: 'PM'},
-    {name: 'Saint Vincent and the Grenadines', code: 'VC'},
-    {name: 'Samoa', code: 'WS'},
-    {name: 'San Marino', code: 'SM'},
-    {name: 'Sao Tome and Principe', code: 'ST'},
-    {name: 'Saudi Arabia', code: 'SA'},
-    {name: 'Senegal', code: 'SN'},
-    {name: 'Serbia and Montenegro', code: 'CS'},
-    {name: 'Seychelles', code: 'SC'},
-    {name: 'Sierra Leone', code: 'SL'},
-    {name: 'Singapore', code: 'SG'},
-    {name: 'Slovakia', code: 'SK'},
-    {name: 'Slovenia', code: 'SI'},
-    {name: 'Solomon Islands', code: 'SB'},
-    {name: 'Somalia', code: 'SO'},
-    {name: 'South Africa', code: 'ZA'},
-    {name: 'South Georgia and the South Sandwich Islands', code: 'GS'},
-    {name: 'Spain', code: 'ES'},
-    {name: 'Sri Lanka', code: 'LK'},
-    {name: 'Sudan', code: 'SD'},
-    {name: 'Suriname', code: 'SR'},
-    {name: 'Svalbard and Jan Mayen', code: 'SJ'},
-    {name: 'Swaziland', code: 'SZ'},
-    {name: 'Sweden', code: 'SE'},
-    {name: 'Switzerland', code: 'CH'},
-    {name: 'Syrian Arab Republic', code: 'SY'},
-    {name: 'Taiwan, Province of China', code: 'TW'},
-    {name: 'Tajikistan', code: 'TJ'},
-    {name: 'Tanzania, United Republic of', code: 'TZ'},
-    {name: 'Thailand', code: 'TH'},
-    {name: 'Timor-Leste', code: 'TL'},
-    {name: 'Togo', code: 'TG'},
-    {name: 'Tokelau', code: 'TK'},
-    {name: 'Tonga', code: 'TO'},
-    {name: 'Trinidad and Tobago', code: 'TT'},
-    {name: 'Tunisia', code: 'TN'},
-    {name: 'Turkey', code: 'TR'},
-    {name: 'Turkmenistan', code: 'TM'},
-    {name: 'Turks and Caicos Islands', code: 'TC'},
-    {name: 'Tuvalu', code: 'TV'},
-    {name: 'Uganda', code: 'UG'},
-    {name: 'Ukraine', code: 'UA'},
-    {name: 'United Arab Emirates', code: 'AE'},
-    {name: 'United Kingdom', code: 'GB'},
-    {name: 'United States', code: 'US'},
-    {name: 'United States Minor Outlying Islands', code: 'UM'},
-    {name: 'Uruguay', code: 'UY'},
-    {name: 'Uzbekistan', code: 'UZ'},
-    {name: 'Vanuatu', code: 'VU'},
-    {name: 'Venezuela', code: 'VE'},
-    {name: 'Viet Nam', code: 'VN'},
-    {name: 'Virgin Islands, British', code: 'VG'},
-    {name: 'Virgin Islands, U.S.', code: 'VI'},
-    {name: 'Wallis and Futuna', code: 'WF'},
-    {name: 'Western Sahara', code: 'EH'},
-    {name: 'Yemen', code: 'YE'},
-    {name: 'Zambia', code: 'ZM'},
-    {name: 'Zimbabwe', code: 'ZW'}
+  {
+    name: 'Afghanistan',
+    code: 'AF',
+    continent: 'Asia'
+  },
+  {
+    name: 'Aland Islands',
+    code: 'AX',
+    continent: 'Europe'
+  },
+  {
+    name: 'Albania',
+    code: 'AL',
+    continent: 'Europe'
+  },
+  {
+    name: 'Algeria',
+    code: 'DZ',
+    continent: 'Africa'
+  },
+  {
+    name: 'American Samoa',
+    code: 'AS',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Andorra',
+    code: 'AD',
+    continent: 'Europe'
+  },
+  {
+    name: 'Angola',
+    code: 'AO',
+    continent: 'Africa'
+  },
+  {
+    name: 'Anguilla',
+    code: 'AI',
+    continent: 'North America'
+  },
+  {
+    name: 'Antarctica',
+    code: 'AQ',
+    continent: 'Antarctica'
+  },
+  {
+    name: 'Antigua and Barbuda',
+    code: 'AG',
+    continent: 'North America'
+  },
+  {
+    name: 'Argentina',
+    code: 'AR',
+    continent: 'South America'
+  },
+  {
+    name: 'Armenia',
+    code: 'AM',
+    continent: 'Asia'
+  },
+  {
+    name: 'Aruba',
+    code: 'AW',
+    continent: 'North America'
+  },
+  {
+    name: 'Australia',
+    code: 'AU',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Austria',
+    code: 'AT',
+    continent: 'Europe'
+  },
+  {
+    name: 'Azerbaijan',
+    code: 'AZ',
+    continent: 'Asia'
+  },
+  {
+    name: 'Bahamas',
+    code: 'BS',
+    continent: 'North America'
+  },
+  {
+    name: 'Bahrain',
+    code: 'BH',
+    continent: 'Asia'
+  },
+  {
+    name: 'Bangladesh',
+    code: 'BD',
+    continent: 'Asia'
+  },
+  {
+    name: 'Barbados',
+    code: 'BB',
+    continent: 'North America'
+  },
+  {
+    name: 'Belarus',
+    code: 'BY',
+    continent: 'Europe'
+  },
+  {
+    name: 'Belgium',
+    code: 'BE',
+    continent: 'Europe'
+  },
+  {
+    name: 'Belize',
+    code: 'BZ',
+    continent: 'North America'
+  },
+  {
+    name: 'Benin',
+    code: 'BJ',
+    continent: 'Africa'
+  },
+  {
+    name: 'Bermuda',
+    code: 'BM',
+    continent: 'North America'
+  },
+  {
+    name: 'Bhutan',
+    code: 'BT',
+    continent: 'Asia'
+  },
+  {
+    name: 'Bolivia',
+    code: 'BO',
+    continent: 'South America'
+  },
+  {
+    name: 'Bosnia and Herzegovina',
+    code: 'BA',
+    continent: 'Europe'
+  },
+  {
+    name: 'Botswana',
+    code: 'BW',
+    continent: 'Africa'
+  },
+  {
+    name: 'Bouvet Island',
+    code: 'BV',
+    continent: 'Antarctica'
+  },
+  {
+    name: 'Brazil',
+    code: 'BR',
+    continent: 'South America'
+  },
+  {
+    name: 'British Indian Ocean Territory',
+    code: 'IO',
+    continent: 'Asia'
+  },
+  {
+    name: 'Brunei Darussalam',
+    code: 'BN',
+    continent: 'Asia'
+  },
+  {
+    name: 'Bulgaria',
+    code: 'BG',
+    continent: 'Europe'
+  },
+  {
+    name: 'Burkina Faso',
+    code: 'BF',
+    continent: 'Africa'
+  },
+  {
+    name: 'Burundi',
+    code: 'BI',
+    continent: 'Africa'
+  },
+  {
+    name: 'Cambodia',
+    code: 'KH',
+    continent: 'Asia'
+  },
+  {
+    name: 'Cameroon',
+    code: 'CM',
+    continent: 'Africa'
+  },
+  {
+    name: 'Canada',
+    code: 'CA',
+    continent: 'North America'
+  },
+  {
+    name: 'Cape Verde',
+    code: 'CV',
+    continent: 'Africa'
+  },
+  {
+    name: 'Cayman Islands',
+    code: 'KY',
+    continent: 'North America'
+  },
+  {
+    name: 'Central African Republic',
+    code: 'CF',
+    continent: 'Africa'
+  },
+  {
+    name: 'Chad',
+    code: 'TD',
+    continent: 'Africa'
+  },
+  {
+    name: 'Chile',
+    code: 'CL',
+    continent: 'South America'
+  },
+  {
+    name: 'China',
+    code: 'CN',
+    continent: 'Asia'
+  },
+  {
+    name: 'Christmas Island',
+    code: 'CX',
+    continent: 'Asia'
+  },
+  {
+    name: 'Cocos (Keeling) Islands',
+    code: 'CC',
+    continent: 'Asia'
+  },
+  {
+    name: 'Colombia',
+    code: 'CO',
+    continent: 'South America'
+  },
+  {
+    name: 'Comoros',
+    code: 'KM',
+    continent: 'Africa'
+  },
+  {
+    name: 'Congo',
+    code: 'CG',
+    continent: 'Africa'
+  },
+  {
+    name: 'Congo, The Democratic Republic of the',
+    code: 'CD',
+    continent: 'Africa'
+  },
+  {
+    name: 'Cook Islands',
+    code: 'CK',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Costa Rica',
+    code: 'CR',
+    continent: 'North America'
+  },
+  {
+    name: 'Cote D\'Ivoire',
+    code: 'CI',
+    continent: 'Africa'
+  },
+  {
+    name: 'Croatia',
+    code: 'HR',
+    continent: 'Europe'
+  },
+  {
+    name: 'Cuba',
+    code: 'CU',
+    continent: 'North America'
+  },
+  {
+    name: 'Cyprus',
+    code: 'CY',
+    continent: 'Europe'
+  },
+  {
+    name: 'Czech Republic',
+    code: 'CZ',
+    continent: 'Europe'
+  },
+  {
+    name: 'Denmark',
+    code: 'DK',
+    continent: 'Europe'
+  },
+  {
+    name: 'Djibouti',
+    code: 'DJ',
+    continent: 'Africa'
+  },
+  {
+    name: 'Dominica',
+    code: 'DM',
+    continent: 'North America'
+  },
+  {
+    name: 'Dominican Republic',
+    code: 'DO',
+    continent: 'North America'
+  },
+  {
+    name: 'Ecuador',
+    code: 'EC',
+    continent: 'South America'
+  },
+  {
+    name: 'Egypt',
+    code: 'EG',
+    continent: 'Africa'
+  },
+  {
+    name: 'El Salvador',
+    code: 'SV',
+    continent: 'North America'
+  },
+  {
+    name: 'Equatorial Guinea',
+    code: 'GQ',
+    continent: 'Africa'
+  },
+  {
+    name: 'Eritrea',
+    code: 'ER',
+    continent: 'Africa'
+  },
+  {
+    name: 'Estonia',
+    code: 'EE',
+    continent: 'Europe'
+  },
+  {
+    name: 'Ethiopia',
+    code: 'ET',
+    continent: 'Africa'
+  },
+  {
+    name: 'Falkland Islands (Malvinas)',
+    code: 'FK',
+    continent: 'South America'
+  },
+  {
+    name: 'Faroe Islands',
+    code: 'FO',
+    continent: 'Europe'
+  },
+  {
+    name: 'Fiji',
+    code: 'FJ',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Finland',
+    code: 'FI',
+    continent: 'Europe'
+  },
+  {
+    name: 'France',
+    code: 'FR',
+    continent: 'Europe'
+  },
+  {
+    name: 'French Guiana',
+    code: 'GF',
+    continent: 'South America'
+  },
+  {
+    name: 'French Polynesia',
+    code: 'PF',
+    continent: 'Oceania'
+  },
+  {
+    name: 'French Southern Territories',
+    code: 'TF',
+    continent: 'Antarctica'
+  },
+  {
+    name: 'Gabon',
+    code: 'GA',
+    continent: 'Africa'
+  },
+  {
+    name: 'Gambia',
+    code: 'GM',
+    continent: 'Africa'
+  },
+  {
+    name: 'Georgia',
+    code: 'GE',
+    continent: 'Asia'
+  },
+  {
+    name: 'Germany',
+    code: 'DE',
+    continent: 'Europe'
+  },
+  {
+    name: 'Ghana',
+    code: 'GH',
+    continent: 'Africa'
+  },
+  {
+    name: 'Gibraltar',
+    code: 'GI',
+    continent: 'Europe'
+  },
+  {
+    name: 'Greece',
+    code: 'GR',
+    continent: 'Europe'
+  },
+  {
+    name: 'Greenland',
+    code: 'GL',
+    continent: 'North America'
+  },
+  {
+    name: 'Grenada',
+    code: 'GD',
+    continent: 'North America'
+  },
+  {
+    name: 'Guadeloupe',
+    code: 'GP',
+    continent: 'North America'
+  },
+  {
+    name: 'Guam',
+    code: 'GU',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Guatemala',
+    code: 'GT',
+    continent: 'North America'
+  },
+  {
+    name: 'Guernsey',
+    code: 'GG',
+    continent: 'Europe'
+  },
+  {
+    name: 'Guinea',
+    code: 'GN',
+    continent: 'Africa'
+  },
+  {
+    name: 'Guinea-Bissau',
+    code: 'GW',
+    continent: 'Africa'
+  },
+  {
+    name: 'Guyana',
+    code: 'GY',
+    continent: 'South America'
+  },
+  {
+    name: 'Haiti',
+    code: 'HT',
+    continent: 'North America'
+  },
+  {
+    name: 'Heard Island and Mcdonald Islands',
+    code: 'HM',
+    continent: 'Antarctica'
+  },
+  {
+    name: 'Holy See (Vatican City State)',
+    code: 'VA',
+    continent: 'Europe'
+  },
+  {
+    name: 'Honduras',
+    code: 'HN',
+    continent: 'North America'
+  },
+  {
+    name: 'Hong Kong',
+    code: 'HK',
+    continent: 'Asia'
+  },
+  {
+    name: 'Hungary',
+    code: 'HU',
+    continent: 'Europe'
+  },
+  {
+    name: 'Iceland',
+    code: 'IS',
+    continent: 'Europe'
+  },
+  {
+    name: 'India',
+    code: 'IN',
+    continent: 'Asia'
+  },
+  {
+    name: 'Indonesia',
+    code: 'ID',
+    continent: 'Asia'
+  },
+  {
+    name: 'Iran, Islamic Republic Of',
+    code: 'IR',
+    continent: 'Asia'
+  },
+  {
+    name: 'Iraq',
+    code: 'IQ',
+    continent: 'Asia'
+  },
+  {
+    name: 'Ireland',
+    code: 'IE',
+    continent: 'Europe'
+  },
+  {
+    name: 'Isle of Man',
+    code: 'IM',
+    continent: 'Europe'
+  },
+  {
+    name: 'Israel',
+    code: 'IL',
+    continent: 'Asia'
+  },
+  {
+    name: 'Italy',
+    code: 'IT',
+    continent: 'Europe'
+  },
+  {
+    name: 'Jamaica',
+    code: 'JM',
+    continent: 'North America'
+  },
+  {
+    name: 'Japan',
+    code: 'JP',
+    continent: 'Asia'
+  },
+  {
+    name: 'Jersey',
+    code: 'JE',
+    continent: 'Europe'
+  },
+  {
+    name: 'Jordan',
+    code: 'JO',
+    continent: 'Asia'
+  },
+  {
+    name: 'Kazakhstan',
+    code: 'KZ',
+    continent: 'Asia'
+  },
+  {
+    name: 'Kenya',
+    code: 'KE',
+    continent: 'Africa'
+  },
+  {
+    name: 'Kiribati',
+    code: 'KI',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Korea, Democratic People\'S Republic of',
+    code: 'KP',
+    continent: 'Asia'
+  },
+  {
+    name: 'Korea, Republic of',
+    code: 'KR',
+    continent: 'Asia'
+  },
+  {
+    name: 'Kuwait',
+    code: 'KW',
+    continent: 'Asia'
+  },
+  {
+    name: 'Kyrgyzstan',
+    code: 'KG',
+    continent: 'Asia'
+  },
+  {
+    name: 'Lao People\'S Democratic Republic',
+    code: 'LA',
+    continent: 'Asia'
+  },
+  {
+    name: 'Latvia',
+    code: 'LV',
+    continent: 'Europe'
+  },
+  {
+    name: 'Lebanon',
+    code: 'LB',
+    continent: 'Asia'
+  },
+  {
+    name: 'Lesotho',
+    code: 'LS',
+    continent: 'Africa'
+  },
+  {
+    name: 'Liberia',
+    code: 'LR',
+    continent: 'Africa'
+  },
+  {
+    name: 'Libyan Arab Jamahiriya',
+    code: 'LY',
+    continent: 'Africa'
+  },
+  {
+    name: 'Liechtenstein',
+    code: 'LI',
+    continent: 'Europe'
+  },
+  {
+    name: 'Lithuania',
+    code: 'LT',
+    continent: 'Europe'
+  },
+  {
+    name: 'Luxembourg',
+    code: 'LU',
+    continent: 'Europe'
+  },
+  {
+    name: 'Macao',
+    code: 'MO',
+    continent: 'Asia'
+  },
+  {
+    name: 'Macedonia, The Former Yugoslav Republic of',
+    code: 'MK',
+    continent: 'Europe'
+  },
+  {
+    name: 'Madagascar',
+    code: 'MG',
+    continent: 'Africa'
+  },
+  {
+    name: 'Malawi',
+    code: 'MW',
+    continent: 'Africa'
+  },
+  {
+    name: 'Malaysia',
+    code: 'MY',
+    continent: 'Asia'
+  },
+  {
+    name: 'Maldives',
+    code: 'MV',
+    continent: 'Asia'
+  },
+  {
+    name: 'Mali',
+    code: 'ML',
+    continent: 'Africa'
+  },
+  {
+    name: 'Malta',
+    code: 'MT',
+    continent: 'Europe'
+  },
+  {
+    name: 'Marshall Islands',
+    code: 'MH',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Martinique',
+    code: 'MQ',
+    continent: 'North America'
+  },
+  {
+    name: 'Mauritania',
+    code: 'MR',
+    continent: 'Africa'
+  },
+  {
+    name: 'Mauritius',
+    code: 'MU',
+    continent: 'Africa'
+  },
+  {
+    name: 'Mayotte',
+    code: 'YT',
+    continent: 'Africa'
+  },
+  {
+    name: 'Mexico',
+    code: 'MX',
+    continent: 'North America'
+  },
+  {
+    name: 'Micronesia, Federated States of',
+    code: 'FM',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Moldova, Republic of',
+    code: 'MD',
+    continent: 'Europe'
+  },
+  {
+    name: 'Monaco',
+    code: 'MC',
+    continent: 'Europe'
+  },
+  {
+    name: 'Mongolia',
+    code: 'MN',
+    continent: 'Asia'
+  },
+  {
+    name: 'Montserrat',
+    code: 'MS',
+    continent: 'North America'
+  },
+  {
+    name: 'Morocco',
+    code: 'MA',
+    continent: 'Africa'
+  },
+  {
+    name: 'Mozambique',
+    code: 'MZ',
+    continent: 'Africa'
+  },
+  {
+    name: 'Myanmar',
+    code: 'MM',
+    continent: 'Asia'
+  },
+  {
+    name: 'Namibia',
+    code: 'NA',
+    continent: 'Africa'
+  },
+  {
+    name: 'Nauru',
+    code: 'NR',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Nepal',
+    code: 'NP',
+    continent: 'Asia'
+  },
+  {
+    name: 'Netherlands',
+    code: 'NL',
+    continent: 'Europe'
+  },
+  {
+    name: 'Netherlands Antilles',
+    code: 'AN',
+    continent: 'South America'
+  },
+  {
+    name: 'New Caledonia',
+    code: 'NC',
+    continent: 'Oceania'
+  },
+  {
+    name: 'New Zealand',
+    code: 'NZ',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Nicaragua',
+    code: 'NI',
+    continent: 'North America'
+  },
+  {
+    name: 'Niger',
+    code: 'NE',
+    continent: 'Africa'
+  },
+  {
+    name: 'Nigeria',
+    code: 'NG',
+    continent: 'Africa'
+  },
+  {
+    name: 'Niue',
+    code: 'NU',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Norfolk Island',
+    code: 'NF',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Northern Mariana Islands',
+    code: 'MP',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Norway',
+    code: 'NO',
+    continent: 'Europe'
+  },
+  {
+    name: 'Oman',
+    code: 'OM',
+    continent: 'Asia'
+  },
+  {
+    name: 'Pakistan',
+    code: 'PK',
+    continent: 'Asia'
+  },
+  {
+    name: 'Palau',
+    code: 'PW',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Palestinian Territory, Occupied',
+    code: 'PS',
+    continent: 'Asia'
+  },
+  {
+    name: 'Panama',
+    code: 'PA',
+    continent: 'North America'
+  },
+  {
+    name: 'Papua New Guinea',
+    code: 'PG',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Paraguay',
+    code: 'PY',
+    continent: 'South America'
+  },
+  {
+    name: 'Peru',
+    code: 'PE',
+    continent: 'South America'
+  },
+  {
+    name: 'Philippines',
+    code: 'PH',
+    continent: 'Asia'
+  },
+  {
+    name: 'Pitcairn',
+    code: 'PN',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Poland',
+    code: 'PL',
+    continent: 'Europe'
+  },
+  {
+    name: 'Portugal',
+    code: 'PT',
+    continent: 'Europe'
+  },
+  {
+    name: 'Puerto Rico',
+    code: 'PR',
+    continent: 'North America'
+  },
+  {
+    name: 'Qatar',
+    code: 'QA',
+    continent: 'Asia'
+  },
+  {
+    name: 'Reunion',
+    code: 'RE',
+    continent: 'Africa'
+  },
+  {
+    name: 'Romania',
+    code: 'RO',
+    continent: 'Europe'
+  },
+  {
+    name: 'Russian Federation',
+    code: 'RU',
+    continent: 'Europe'
+  },
+  {
+    name: 'RWANDA',
+    code: 'RW',
+    continent: 'Africa'
+  },
+  {
+    name: 'Saint Helena',
+    code: 'SH',
+    continent: 'Africa'
+  },
+  {
+    name: 'Saint Kitts and Nevis',
+    code: 'KN',
+    continent: 'North America'
+  },
+  {
+    name: 'Saint Lucia',
+    code: 'LC',
+    continent: 'North America'
+  },
+  {
+    name: 'Saint Pierre and Miquelon',
+    code: 'PM',
+    continent: 'North America'
+  },
+  {
+    name: 'Saint Vincent and the Grenadines',
+    code: 'VC',
+    continent: 'North America'
+  },
+  {
+    name: 'Samoa',
+    code: 'WS',
+    continent: 'Oceania'
+  },
+  {
+    name: 'San Marino',
+    code: 'SM',
+    continent: 'Europe'
+  },
+  {
+    name: 'Sao Tome and Principe',
+    code: 'ST',
+    continent: 'Africa'
+  },
+  {
+    name: 'Saudi Arabia',
+    code: 'SA',
+    continent: 'Asia'
+  },
+  {
+    name: 'Senegal',
+    code: 'SN',
+    continent: 'Africa'
+  },
+  {
+    name: 'Serbia and Montenegro',
+    code: 'CS',
+    continent: 'Europe'
+  },
+  {
+    name: 'Seychelles',
+    code: 'SC',
+    continent: 'Africa'
+  },
+  {
+    name: 'Sierra Leone',
+    code: 'SL',
+    continent: 'Africa'
+  },
+  {
+    name: 'Singapore',
+    code: 'SG',
+    continent: 'Asia'
+  },
+  {
+    name: 'Slovakia',
+    code: 'SK',
+    continent: 'Europe'
+  },
+  {
+    name: 'Slovenia',
+    code: 'SI',
+    continent: 'Europe'
+  },
+  {
+    name: 'Solomon Islands',
+    code: 'SB',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Somalia',
+    code: 'SO',
+    continent: 'Africa'
+  },
+  {
+    name: 'South Africa',
+    code: 'ZA',
+    continent: 'Africa'
+  },
+  {
+    name: 'South Georgia and the South Sandwich Islands',
+    code: 'GS',
+    continent: 'Antarctica'
+  },
+  {
+    name: 'Spain',
+    code: 'ES',
+    continent: 'Europe'
+  },
+  {
+    name: 'Sri Lanka',
+    code: 'LK',
+    continent: 'Asia'
+  },
+  {
+    name: 'Sudan',
+    code: 'SD',
+    continent: 'Africa'
+  },
+  {
+    name: 'Suriname',
+    code: 'SR',
+    continent: 'South America'
+  },
+  {
+    name: 'Svalbard and Jan Mayen',
+    code: 'SJ',
+    continent: 'Europe'
+  },
+  {
+    name: 'Swaziland',
+    code: 'SZ',
+    continent: 'Africa'
+  },
+  {
+    name: 'Sweden',
+    code: 'SE',
+    continent: 'Europe'
+  },
+  {
+    name: 'Switzerland',
+    code: 'CH',
+    continent: 'Europe'
+  },
+  {
+    name: 'Syrian Arab Republic',
+    code: 'SY',
+    continent: 'Asia'
+  },
+  {
+    name: 'Taiwan, Province of China',
+    code: 'TW',
+    continent: 'Asia'
+  },
+  {
+    name: 'Tajikistan',
+    code: 'TJ',
+    continent: 'Asia'
+  },
+  {
+    name: 'Tanzania, United Republic of',
+    code: 'TZ',
+    continent: 'Africa'
+  },
+  {
+    name: 'Thailand',
+    code: 'TH',
+    continent: 'Asia'
+  },
+  {
+    name: 'Timor-Leste',
+    code: 'TL',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Togo',
+    code: 'TG',
+    continent: 'Africa'
+  },
+  {
+    name: 'Tokelau',
+    code: 'TK',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Tonga',
+    code: 'TO',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Trinidad and Tobago',
+    code: 'TT',
+    continent: 'North America'
+  },
+  {
+    name: 'Tunisia',
+    code: 'TN',
+    continent: 'Africa'
+  },
+  {
+    name: 'Turkey',
+    code: 'TR',
+    continent: 'Asia'
+  },
+  {
+    name: 'Turkmenistan',
+    code: 'TM',
+    continent: 'Asia'
+  },
+  {
+    name: 'Turks and Caicos Islands',
+    code: 'TC',
+    continent: 'North America'
+  },
+  {
+    name: 'Tuvalu',
+    code: 'TV',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Uganda',
+    code: 'UG',
+    continent: 'Africa'
+  },
+  {
+    name: 'Ukraine',
+    code: 'UA',
+    continent: 'Europe'
+  },
+  {
+    name: 'United Arab Emirates',
+    code: 'AE',
+    continent: 'Asia'
+  },
+  {
+    name: 'United Kingdom',
+    code: 'GB',
+    continent: 'Europe'
+  },
+  {
+    name: 'United States',
+    code: 'US',
+    continent: 'North America'
+  },
+  {
+    name: 'United States Minor Outlying Islands',
+    code: 'UM',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Uruguay',
+    code: 'UY',
+    continent: 'South America'
+  },
+  {
+    name: 'Uzbekistan',
+    code: 'UZ',
+    continent: 'Asia'
+  },
+  {
+    name: 'Vanuatu',
+    code: 'VU',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Venezuela',
+    code: 'VE',
+    continent: 'South America'
+  },
+  {
+    name: 'Viet Nam',
+    code: 'VN',
+    continent: 'Asia'
+  },
+  {
+    name: 'Virgin Islands, British',
+    code: 'VG',
+    continent: 'North America'
+  },
+  {
+    name: 'Virgin Islands, U.S.',
+    code: 'VI',
+    continent: 'North America'
+  },
+  {
+    name: 'Wallis and Futuna',
+    code: 'WF',
+    continent: 'Oceania'
+  },
+  {
+    name: 'Western Sahara',
+    code: 'EH',
+    continent: 'Africa'
+  },
+  {
+    name: 'Yemen',
+    code: 'YE',
+    continent: 'Asia'
+  },
+  {
+    name: 'Zambia',
+    code: 'ZM',
+    continent: 'Africa'
+  },
+  {
+    name: 'Zimbabwe',
+    code: 'ZW',
+    continent: 'Africa'
+  }
 ]);

--- a/tests/dummy/app/templates/ember-widgets/select.hbs
+++ b/tests/dummy/app/templates/ember-widgets/select.hbs
@@ -55,6 +55,31 @@
   </div>
   <div class="row">
     <div class="col-md-6">
+      <h3>Select with Grouped Options</h3>
+      <div class="example-container">
+        {{select-component
+          content=model
+          prompt="Select a Country"
+          optionLabelPath="name"
+          optionValuePath="code"
+          optionGroupPath="continent"
+          selection=selection
+          placeholder="Search"
+        }}
+      </div>
+
+      <h4 class="bumper-30">Application.hbs</h4>
+      <div class="highlight">
+<pre class="prettyprint lang-html">&#123;&#123;select-component
+  content=model
+  prompt="Select a Country"
+  optionLabelPath="name"
+  optionValuePath="code"
+  optionGroupPath="continent"
+  selection=selection
+  placeholder="Search"
+&#125;&#125;</pre>
+      </div>
     </div>
     <div class="col-md-6">
       <h3>Multi-Select <small>Small</small></h3>


### PR DESCRIPTION
Add example in documentation of `select-component` to show grouped options. Add continent data to `countries.js` to have sample data to group by.

![image](https://user-images.githubusercontent.com/42778466/54005811-db954180-4128-11e9-84c8-8b7136891d93.png)
