### PR TITLE
Add collapsible grouped headers to select-component

### DIFF
--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -381,7 +381,7 @@ export default Ember.Component.extend(
       }
     });
     return result;
-  }).property('preparedContent', 'preparedContent.[]', 'optionGroupPath', 'labels.[]', 'groupSortFunction', 'collapsedGroupHeaders.[]'),
+  }).property('preparedContent', 'preparedContent.[]', 'optionGroupPath', 'labels.[]', 'groupSortFunction', 'isGroupHeaderCollapsible', 'collapsedGroupHeaders.[]'),
 
   // Array that contains the names of all grouped headers that are collapsed
   collapsedGroupHeaders: Ember.A(),

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -35,6 +35,8 @@ export default Ember.Component.extend(
   titleOnOptions: false,
   // If isSelect is true, we will not show the search box
   isSelect: false,
+  // If isGroupHeaderCollapsible is true, and there is a optionGroupPath, the group header is collapsible
+  isGroupHeaderCollapsible: false,
   // Align dropdown-menu above the button
   isDropup: false,
   // Align dropdown-menu to the right of the button
@@ -345,6 +347,8 @@ export default Ember.Component.extend(
   groupedContent: Ember.computed(function() {
     var path = this.get('optionGroupPath');
     var content = this.get('preparedContent');
+    // Only allow grouped headers to be collapsed if isGroupHeaderCollapsible is true
+    var collapsedHeaders = this.get('isGroupHeaderCollapsible') ? this.get('collapsedGroupHeaders') : Ember.A();
     if (!path) {
       return Ember.A(content);
     }
@@ -356,19 +360,31 @@ export default Ember.Component.extend(
     });
     var sortedGroupObjs = groupObjs.sort(this.get('groupSortFunction'));
     var result = Ember.A();
+    // If grouped header is in collapsedHeaders list, hide the child options by removing the child members from the
+    // backing object
+    // In order to hide items from the list, the object has to be removed from the backing object due to the use of
+    // vertical-collection's occlusion. If CSS were to be used to hide list items, there would not be a method to
+    // schedule vertical-collection's re-measure and re-render.
     sortedGroupObjs.forEach(function(groupObj) {
+      var isGroupHeaderCollapsed = collapsedHeaders.includes(groupObj.name);
       if (groupObj.name) {
         result.pushObject(
           Ember.Object.create({
             isGroupOption: true,
+            isGroupHeaderCollapsed: isGroupHeaderCollapsed,
             name: groupObj.name
           })
         );
       }
-      result.pushObjects(groupObj.members);
+      if (!isGroupHeaderCollapsed) {
+        result.pushObjects(groupObj.members);
+      }
     });
     return result;
-  }).property('preparedContent', 'preparedContent.[]', 'optionGroupPath', 'labels.[]', 'groupSortFunction'),
+  }).property('preparedContent', 'preparedContent.[]', 'optionGroupPath', 'labels.[]', 'groupSortFunction', 'collapsedGroupHeaders.[]'),
+
+  // Array that contains the names of all grouped headers that are collapsed
+  collapsedGroupHeaders: Ember.A(),
 
   isLoading: false,
   isLoaded: Ember.computed.not('isLoading'),
@@ -654,6 +670,15 @@ export default Ember.Component.extend(
         return;
       }
       return this.toggleProperty('showDropdown');
+    },
+
+    toggleGroupHeader: function(groupHeaderName) {
+      if (this.get('collapsedGroupHeaders').includes(groupHeaderName)) {
+        this.get('collapsedGroupHeaders').removeObject(groupHeaderName);
+      }
+      else {
+        this.get('collapsedGroupHeaders').pushObject(groupHeaderName);
+      }
     },
 
     hideDropdown: function() {

--- a/addon/styles/select.less
+++ b/addon/styles/select.less
@@ -316,6 +316,10 @@
       background-color: #4c88e5;
       color: #fff;
     }
+
+    .collapsible-group-header {
+      cursor: pointer;
+    }
   }
 }
 

--- a/addon/views/select-option.js
+++ b/addon/views/select-option.js
@@ -9,6 +9,8 @@ export default Ember.View.extend({
   layoutName: 'select-item-layout',
   classNames: 'ember-select-result-item',
   classNameBindings: Ember.A(['content.isGroupOption:ember-select-group', 'isHighlighted:highlighted']),
+  collapsedGroupHeaderIcon: 'fas fa-caret-right',
+  expandedGroupHeaderIcon: 'fas fa-caret-down',
   isHighlighted: Ember.computed(function() {
     return this.get('highlighted') === this.get('content');
   }).property('highlighted', 'content'),

--- a/app/templates/multi-select.hbs
+++ b/app/templates/multi-select.hbs
@@ -37,6 +37,7 @@
           selection=selection
           showDropdown=showDropdown
           titleOnOptions=titleOnOptions
+          isGroupHeaderCollapsible=isGroupHeaderCollapsible
           selectComponent=this
         }}
       {{/vertical-collection}}

--- a/app/templates/select-item-layout.hbs
+++ b/app/templates/select-item-layout.hbs
@@ -1,5 +1,7 @@
 {{#if view.content.isGroupOption}}
-  {{view.content.name}}
+  <div {{action "toggleGroupHeader" view.content.name}} class="{{if view.isGroupHeaderCollapsible 'collapsible-group-header'}}">
+    <i class={{if view.isGroupHeaderCollapsible (if view.content.isGroupHeaderCollapsed view.collapsedGroupHeaderIcon view.expandedGroupHeaderIcon)}}></i> {{view.content.name}}
+  </div>
 {{else}}
   {{#if view.titleOnOptions}}
     <span {{bind-attr title=view.label}}>

--- a/app/templates/select-list-view-partial.hbs
+++ b/app/templates/select-list-view-partial.hbs
@@ -11,6 +11,7 @@
       selection=selection
       showDropdown=showDropdown
       titleOnOptions=titleOnOptions
+      isGroupHeaderCollapsible=isGroupHeaderCollapsible
       selectComponent=this
     }}
   {{/vertical-collection}}

--- a/tests/dummy/app/templates/ember-widgets/select.hbs
+++ b/tests/dummy/app/templates/ember-widgets/select.hbs
@@ -105,4 +105,62 @@
       </div>
     </div>
   </div>
+  <div class="row">
+    <div class="col-md-6">
+      <h3>Select with Collapsible Group Headers</h3>
+      <div class="example-container">
+        {{select-component
+          content=model
+          prompt="Select a Country"
+          optionLabelPath="name"
+          optionValuePath="code"
+          optionGroupPath="continent"
+          isGroupHeaderCollapsible=true
+          selection=selection
+          placeholder="Search"
+        }}
+      </div>
+
+      <h4 class="bumper-30">Application.hbs</h4>
+      <div class="highlight">
+<pre class="prettyprint lang-html">&#123;&#123;select-component
+  content=model
+  prompt="Select a Country"
+  optionLabelPath="name"
+  optionValuePath="code"
+  optionGroupPath="continent"
+  isGroupHeaderCollapsible=true
+  selection=selection
+  placeholder="Search"
+&#125;&#125;</pre>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <h3>Multi-Select with Collapsible Group Headers</h3>
+      <div class="example-container">
+        {{multi-select-component
+          content=model
+          optionLabelPath="name"
+          optionValuePath="code"
+          optionGroupPath="continent"
+          isGroupHeaderCollapsible=true
+          classNames="multi-select-example"
+          placeholder="Select a country..."
+        }}
+      </div>
+
+      <h4 class="bumper-30">Application.hbs</h4>
+      <div class="highlight">
+<pre class="prettyprint lang-html">&#123;&#123;multi-select-component
+  content=model
+  optionLabelPath="name"
+  optionValuePath="code"
+  optionGroupPath="continent"
+  isGroupHeaderCollapsible=true
+  classNames="multi-select-example"
+  placeholder="Select a country..."
+&#125;&#125;</pre>
+      </div>
+    </div>
+  </div>
 </div>

--- a/tests/unit/components/select-component-test.js
+++ b/tests/unit/components/select-component-test.js
@@ -311,3 +311,54 @@ test('optionValuePath with nested valuePath', function(assert) {
   });
   assert.equal(obj2, select.get('selection'), 'The right selection is retrieved');
 });
+
+test('Test groupedContent, headers collapsed', function(assert) {
+  assert.expect(9);
+
+  select = this.subject({
+    content: animalData(),
+    optionLabelPath: 'name',
+    optionValuePath: 'name',
+    optionGroupPath: 'sound',
+    isGroupHeaderCollapsible: true
+  });
+
+  var expected = [
+    'Bark',
+    'Sea Lion',
+    'Wolf',
+    'Squawk',
+    'bark',
+  ];
+
+  select.set('collapsedGroupHeaders', Ember.A(['Squawk', 'bark']));
+
+  var actual = select.get('groupedContent');
+  contentEqual(assert, expected, actual, [0, 3, 4]);
+});
+
+test('Test groupedContent, all headers expanded', function(assert) {
+  assert.expect(12);
+
+  select = this.subject({
+    content: animalData(),
+    optionLabelPath: 'name',
+    optionValuePath: 'name',
+    optionGroupPath: 'sound',
+    isGroupHeaderCollapsible: true
+  });
+
+  var expected = [
+    'Bark',
+    'Sea Lion',
+    'Wolf',
+    'Squawk',
+    'Crow',
+    'Sparrow',
+    'bark',
+    'Dog'
+  ];
+
+  var actual = select.get('groupedContent');
+  contentEqual(assert, expected, actual, [0, 3, 6]);
+});


### PR DESCRIPTION
Add ability to collapse/expand group headers in `select-component` and `multi-select-component`. `optionGroupPath` should be set and `isGroupHeaderCollapsible=true` on the select.

There were 2 possible approaches to implementing the hiding of the list items after the header is collapsed
1. Use CSS `display: none` to hide the list item if the header is collapsed
2. Remove the list item from the backing JavaScript data structure for the select list

Approach 1 was chosen was approach 2 was not feasible. `vertical-collection` is used to render the list items to utilize its occlusion performance capability. There currently is not a built-in mechanism in `vertical-collection` to schedule a re-measure or a re-render.

![collapsible-group-headers](https://user-images.githubusercontent.com/42778466/54151395-1c36d880-4411-11e9-8aa8-59bde50b4f6e.gif)
