### PR TITLE
Add `customFilter` option to `select-component` to supply an additional filter on each list item

### DIFF
--- a/tests/unit/components/select-component-test.js
+++ b/tests/unit/components/select-component-test.js
@@ -198,6 +198,37 @@ test('Test query matching', function(assert) {
   assert.equal(select.get('filteredContent').length, 1, 'duplicated spaces in the source string should be removed before matching');
 });
 
+test('Test filteredContent matching with customFilter', function(assert) {
+  assert.expect(5);
+  select = this.subject({
+    content: ['foo', 'bana$  na', 'bar ca', 'baz'],
+  });
+  assert.equal(select.get('filteredContent').length, 4, 'using default customFilter should return the full list of options');
+  select.set('customFilter', item => item.includes('ba'));
+  assert.equal(select.get('filteredContent').length, 3, 'only list items matching the customFilter function are shown');
+  select.set('customFilter', () => false);
+  assert.equal(select.get('filteredContent').length, 0, 'customFilter with falsy value should not return any options');
+  select.set('customFilter', null );
+  assert.equal(select.get('filteredContent').length, 4, 'customFilter with null value should return all options');
+  select.set('customFilter', () => true );
+  assert.equal(select.get('filteredContent').length, 4, 'customFilter with truthy value should return all options');
+});
+
+test('Test filteredContent matching with search query and customFilter', function(assert) {
+  assert.expect(3);
+  select = this.subject({
+    content: ['foo', 'bana$  na', 'bar ca', 'baz'],
+  });
+  select.set('query', null);
+  assert.equal(select.get('filteredContent').length, 4, 'using default customFilter and null query should return the full list of options');
+  select.set('query', 'baz');
+  select.set('customFilter', item => item.includes('ba'));
+  assert.equal(select.get('filteredContent').length, 1, 'only list items matching the customFilter function and query are shown');
+  select.set('query', null);
+  select.set('customFilter', item => item );
+  assert.equal(select.get('filteredContent').length, 4, 'customFilter based on truthy item and null query should return all options');
+});
+
 test('optionValuePath with POJOs', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Add overridable `customFilter` function to `select-component` to allow an additional filter on each list item to be applied. The default implementation of the `customFilter` function is to filter out all items that are `!isNone(item)`.

This will enable the extension of `select-component` to add an additional custom filter to the select list. The `select-component` already has built-in search capability that narrows the list of content down based on the query entered in the textbox . Building on the [pre-existing implementation](https://github.com/Addepar/ember-widgets/blob/7515e048176958c81341389ecb58797e1d553ff9/addon/components/select-component.js#L319), a second filter for `filteredContent` was added. It was discussed whether or not to add functionality to allow a list of filters to be passed into `select-component`, but ultimately we wanted the implementation to preserve the pre-built in capability of the `matcher` function.