### PR TITLE
Change implementation of tab view to a tab component

### DIFF
--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -110,7 +110,7 @@ export default Ember.Component.extend(
   // possibly says 'create item' or something along that line
   selectMenuView: null,
   // This provides a place for adding tabs to further divide the select list results
-  tabView: null,
+  tabComponentName: null,
   tooltipItemViewClass: SelectTooltipOptionView,
   originalItemViewClass: SelectOptionView,
 

--- a/app/templates/select.hbs
+++ b/app/templates/select.hbs
@@ -16,8 +16,8 @@
       {{view searchView selectComponent=this}}
     </div>
   {{/unless}}
-  {{#if tabView}}
-    {{view tabView selectComponent=this}}
+  {{#if tabComponentName}}
+    {{component tabComponentName selectComponent=this}}
   {{/if}}
   {{#if showDropdown}}
     {{partial listViewPartial}}

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 import startApp from '../helpers/start-app';
 import {
@@ -504,12 +505,14 @@ test('shouldEnsureVisible controls whether to ensure visibility', function(asser
   return spy.restore();
 });
 
-test('Can specify a custom view with tabView', function(assert) {
-  assert.expect(3);
-
-  let tabView = Ember.View.extend({
-    layout: Ember.Handlebars.compile("<div class='tab-view'>List of tabs</div>")
-  });
+test('Can specify a custom component with tabComponentName', function(assert) {
+  assert.expect(2);
+  let tabComponentName = 'tab-component';
+  this.register(`component:${tabComponentName}`, Ember.Component.extend());
+  this.register(
+    `template:components/${tabComponentName}`,
+    hbs`<div class='tab-component'>List of tabs</div>`
+  );
 
   select = this.subject({
     content: ['dummy data'],
@@ -519,23 +522,15 @@ test('Can specify a custom view with tabView', function(assert) {
 
   openDropdown(selectElement);
   andThen(function() {
-    return assert.ok(isNotPresent('.tab-view', selectElement), 'Tab view not displayed before specified');
+    return assert.ok(isNotPresent('.tab-component', selectElement), 'Tab component not displayed before specified');
   });
   andThen(function() {
     return Ember.run(function() {
-      return select.set('tabView', tabView);
+      return select.set('tabComponentName', tabComponentName);
     });
   });
   andThen(function() {
-    return assert.ok(isPresent('.tab-view', selectElement), 'Tab view displayed');
-  });
-  andThen(function() {
-    return Ember.run(function() {
-      return select.set('tabView', null);
-    });
-  });
-  return andThen(function() {
-    return assert.ok(isNotPresent('.tab-view', selectElement), 'Tab view no longer displayed');
+    return assert.ok(isPresent('.tab-component', selectElement), 'Tab component displayed');
   });
 });
 


### PR DESCRIPTION
Move from using views to components for `tabView`. This is to aid the upgrade path to Ember 2.x