### PR TITLE
EditableLabel uses the component syntax instead of the view one

### DIFF
--- a/addon/components/editable-label-component.js
+++ b/addon/components/editable-label-component.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  templateName: 'editable-label',
+  layoutName: 'editable-label',
   classNames: ['editable-label'],
   placeholder: '',
   isEditing: false,

--- a/app/templates/editable-label.hbs
+++ b/app/templates/editable-label.hbs
@@ -1,5 +1,5 @@
-{{#if view.isEditing}}
-  {{view view.innerTextField}}
+{{#if isEditing}}
+  {{view innerTextField}}
 {{else}}
-  <span {{action editLabel target="view"}}>{{view.displayName}}</span>
+  <span {{action editLabel}}>{{displayName}}</span>
 {{/if}}


### PR DESCRIPTION
This is likely old code from when this library was relying only on views.