### PR TITLE
Add ability to display number of items under group header

### DIFF
--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -372,7 +372,8 @@ export default Ember.Component.extend(
           Ember.Object.create({
             isGroupOption: true,
             isGroupHeaderCollapsed: isGroupHeaderCollapsed,
-            name: groupObj.name
+            name: groupObj.name,
+            numMembers: groupObj.members.length
           })
         );
       }

--- a/tests/unit/components/select-component-test.js
+++ b/tests/unit/components/select-component-test.js
@@ -393,3 +393,20 @@ test('Test groupedContent, all headers expanded', function(assert) {
   var actual = select.get('groupedContent');
   contentEqual(assert, expected, actual, [0, 3, 6]);
 });
+
+test('Test count of items under group header is correct', function(assert) {
+  assert.expect(1);
+
+  select = this.subject({
+    content: animalData(),
+    optionLabelPath: 'name',
+    optionValuePath: 'name',
+    optionGroupPath: 'sound',
+    isGroupHeaderCollapsible: true
+  });
+
+  select.set('collapsedGroupHeaders', Ember.A(['Squawk', 'bark']));
+
+  var actual = select.get('groupedContent');
+  assert.deepEqual(actual.map(item => Ember.get(item, 'numMembers')), [2, undefined, undefined, 2, 1]);
+});


### PR DESCRIPTION
Add ability to display number of items under group header using `numMembers` property

Example usage:
![image](https://user-images.githubusercontent.com/42778466/61150234-f69a0880-a4b0-11e9-98fe-061e2c107f04.png)