### PR TITLE
Don't propagate the esc event when hiding popovers

### DIFF
--- a/addon/mixins/popover.js
+++ b/addon/mixins/popover.js
@@ -225,7 +225,8 @@ export default Ember.Mixin.create(StyleBindingsMixin, BodyEventListener, {
     var _this = this;
     return function(event) {
       if (event.keyCode === 27 && _this.get('escToCancel')) {
-        return _this.hide();
+        _this.hide();
+        return false;
       }
     };
   }),


### PR DESCRIPTION
This seems like it should be the expected behavior, in general.

@NicholasMohr 