### PR TITLE
[DEPRECATIONS] Remove deprecations raised with Ember 1.13

### DIFF
--- a/addon/components/color-picker-dropdown.js
+++ b/addon/components/color-picker-dropdown.js
@@ -35,7 +35,7 @@ export default Ember.Component.extend(BodyEventListenerMixin, ColorPickerMixin, 
   colorRows: Ember.computed(function() {
     return Ember.A();
   }),
-  setCustomColorObserver: Ember.on('init', Ember.observer(function() {
+  setCustomColorObserver: Ember.on('init', Ember.observer('selectedColor', 'colorRows', function() {
     var selectedColor;
     selectedColor = this.get('selectedColor');
     selectedColor = this.colorToHex(selectedColor);
@@ -45,7 +45,7 @@ export default Ember.Component.extend(BodyEventListenerMixin, ColorPickerMixin, 
       return this.set('customColor', '');
     }
     return this.set('customColor', selectedColor);
-  }, 'selectedColor', 'colorRows')),
+  })),
   /**
    * This is the formatted string of the input color, for which a hashtag "#"
    * is automatically added if it is not present.

--- a/addon/components/multi-select-component.js
+++ b/addon/components/multi-select-component.js
@@ -100,7 +100,7 @@ export default SelectComponent.extend({
 
   // uses single select's "selection" value - adds it to selections and
   // then clears the selection value so that it can be re-selected
-  selectionDidChange: Ember.observer(function() {
+  selectionDidChange: Ember.observer('selection', 'selections.[]', function() {
     var selection, selections;
     selections = this.get('selections');
     selection = this.get('selection');
@@ -111,7 +111,7 @@ export default SelectComponent.extend({
     if (!Ember.isEmpty(selection) && !selections.contains(selection)) {
       return selections.pushObject(selection);
     }
-  }, 'selection', 'selections.[]'),
+  }),
   focusTextField: function() {
     var ref;
     return (ref = this.$('.ember-text-field')) != null ? ref.focus() : void 0;

--- a/addon/components/multi-select-component.js
+++ b/addon/components/multi-select-component.js
@@ -22,7 +22,7 @@ export default SelectComponent.extend({
   // the input field, which is always visible. This helps reducing one tab
   // step to navigate back to the previous component
   tabindex: -1,
-  values: Ember.computed(function(key, value) {
+  values: Ember.computed('selections.[]', function(key, value) {
     var selections, valuePath;
     if (arguments.length === 2) {
       if (!value) {
@@ -42,7 +42,7 @@ export default SelectComponent.extend({
         return selections;
       }
     }
-  }).property('selections.[]'),
+  }),
   selectionItemView: MultiSelectOptionView,
 
   // Invisible span used to make sure there is a good amount of room for either

--- a/addon/components/multi-select-component.js
+++ b/addon/components/multi-select-component.js
@@ -22,9 +22,9 @@ export default SelectComponent.extend({
   // the input field, which is always visible. This helps reducing one tab
   // step to navigate back to the previous component
   tabindex: -1,
-  values: Ember.computed('selections.[]', function(key, value) {
-    var selections, valuePath;
-    if (arguments.length === 2) {
+  values: Ember.computed('selections.[]', {
+    set(key, value) {
+      var selections, valuePath;
       if (!value) {
         return;
       }
@@ -33,7 +33,9 @@ export default SelectComponent.extend({
         return value.contains(Ember.get(item, valuePath));
       })));
       return value;
-    } else {
+    },
+    get() {
+      var selections, valuePath;
       valuePath = this.get('optionValuePath');
       selections = this.get('selections');
       if (valuePath) {

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -394,9 +394,9 @@ export default Ember.Component.extend(
   contentIsEmpty: Ember.computed.empty('content'),
   hasNoResults: Ember.computed.and('isLoaded', 'filteredContentIsEmpty'),
 
-  value: Ember.computed(function(key, value) {
-    var selection, valuePath, content;
-    if (arguments.length === 2) {
+  value: Ember.computed('selection', {
+    set(key, value) {
+      var selection, valuePath, content;
       valuePath = this.get('optionValuePath');
       selection = value;
       content = this.get('content');
@@ -409,7 +409,10 @@ export default Ember.Component.extend(
       }
       this.set('selection', selection);
       return value;
-    } else {
+
+    },
+    get() {
+      var selection, valuePath;
       valuePath = this.get('optionValuePath');
       selection = this.get('selection');
       if (valuePath) {
@@ -418,7 +421,7 @@ export default Ember.Component.extend(
         return selection;
       }
     }
-  }).property('selection'),
+  }),
 
   didInsertElement: function() {
     this._super();
@@ -520,23 +523,22 @@ export default Ember.Component.extend(
   shouldEnsureVisible: true,
 
   // The option that is currently highlighted.
-  highlighted: Ember.computed(function(key, value) {
-    let content = this.get('selectableOptions') || Ember.A();
+  highlighted: Ember.computed('selectableOptions.[]', 'highlightedIndex', 'shouldEnsureVisible', {
+    set(key, value) {
+      let content = this.get('selectableOptions') || Ember.A();
+      let index = value ? content.indexOf(value) : -1;
+      this.setHighlightedIndex(
+        index,
+        this.get('shouldEnsureVisible')
+      );
+      return value || [];
 
-    if (arguments.length === 1) {
-      // Getter
+    },
+    get() {
+      let content = this.get('selectableOptions') || Ember.A();
       return content.objectAt(this.get('highlightedIndex'));
     }
-
-    // Setter
-    let index = value ? content.indexOf(value) : -1;
-    this.setHighlightedIndex(
-      index,
-      this.get('shouldEnsureVisible')
-    );
-    return value || [];
-
-  }).property('selectableOptions.[]', 'highlightedIndex', 'shouldEnsureVisible'),
+  }),
 
   setFocus: function() {
     var activeElem, selectComponent;

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -401,8 +401,8 @@ export default Ember.Component.extend(
       selection = value;
       content = this.get('content');
       if (valuePath && content) {
-        if (typeof content.findProperty === 'function') {
-          selection = content.findProperty(valuePath, value);
+        if (typeof content.findBy === 'function') {
+          selection = content.findBy(valuePath, value);
         } else {
           selection = find(content, matchesProperty(valuePath, value));
         }
@@ -478,7 +478,7 @@ export default Ember.Component.extend(
     if (!(content && defaultPath)) {
       return;
     }
-    return this.set('selection', content.findProperty(defaultPath));
+    return this.set('selection', content.findBy(defaultPath));
   }),
 
   selectableOptionsDidChange: Ember.observer('selectableOptions.[]', 'showDropdown', function() {

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -162,7 +162,7 @@ export default Ember.Component.extend(
     }
     return this._super();
   },
-  updateDropdownLayout: Ember.observer(function() {
+  updateDropdownLayout: Ember.observer('showDropdown', function() {
     var dropdownButton, dropdownButtonHeight, dropdownButtonOffset, dropdownMargin, dropdownMenu, dropdownMenuBottom, dropdownMenuHeight, dropdownMenuOffset, dropdownMenuWidth, dropupMenuTop;
     if ((this.get('_state') || this.get('state')) !== 'inDOM' || this.get('showDropdown') === false) {
       return;
@@ -202,7 +202,7 @@ export default Ember.Component.extend(
     if (highlightedIndex !== -1 && this.get('shouldEnsureVisible')) {
       Ember.run.schedule('afterRender', () => this.ensureVisible(highlightedIndex));
     }
-  }, 'showDropdown'),
+  }),
   onResizeEnd: function() {
     // We need to put this on the run loop, because the resize event came from
     // the window. Otherwise, we get a warning when used in the tests. You have
@@ -242,12 +242,12 @@ export default Ember.Component.extend(
     });
   }).property('itemView'),
 
-  optionLabelPathChanges: Ember.on('init', Ember.observer(function() {
+  optionLabelPathChanges: Ember.on('init', Ember.observer('selection', 'optionLabelPath', function() {
     var labelPath, path;
     labelPath = this.get('optionLabelPath');
     path = labelPath ? "selection." + labelPath : 'selection';
     return Ember.defineProperty(this, 'selectedLabel', Ember.computed.alias(path));
-  }, 'selection', 'optionLabelPath')),
+  })),
 
   searchView: DebouncedTextComponent.extend({
     placeholder: Ember.computed.alias('selectComponent.placeholder'),
@@ -256,7 +256,7 @@ export default Ember.Component.extend(
     // this in a run loop to wait for the event that triggers the showDropdown
     // to finishes before trying to focus the input. Otherwise, focus when be
     // "stolen" from us.
-    showDropdownDidChange: Ember.observer(function() {
+    showDropdownDidChange: Ember.observer('selectComponent.showDropdown', function() {
       // when closing, don't need to focus the now-hidden search box
       if (this.get('selectComponent.showDropdown')) {
         return Ember.run.schedule('afterRender', this, function() {
@@ -269,7 +269,7 @@ export default Ember.Component.extend(
         this.set('value', '');
         this.get('selectComponent').send('valueChanged', '');
       }
-    }, 'selectComponent.showDropdown'),
+    }),
 
     /**
       Delegates to parent view (The select component) to propagate this data up.
@@ -463,7 +463,7 @@ export default Ember.Component.extend(
   customFilter: null,
 
   // TODO(Peter): This needs to be rethought
-  setDefaultSelection: Ember.observer(function() {
+  setDefaultSelection: Ember.observer('content.[]', function() {
     var content, defaultPath;
 
     // do not set default selection if selection is defined
@@ -476,9 +476,9 @@ export default Ember.Component.extend(
       return;
     }
     return this.set('selection', content.findProperty(defaultPath));
-  }, 'content.[]'),
+  }),
 
-  selectableOptionsDidChange: Ember.observer(function() {
+  selectableOptionsDidChange: Ember.observer('selectableOptions.[]', 'showDropdown', function() {
     /*
      * If the dropdown is visible and the selected option is no longer
      * contained in the list of selectableOptions, then force the first
@@ -491,7 +491,7 @@ export default Ember.Component.extend(
         this.set('highlighted', selectableOptions.get('firstObject'));
       }
     }
-  }, 'selectableOptions.[]', 'showDropdown'),
+  }),
 
   /*
    * SELECTION RELATED

--- a/addon/mixins/popover.js
+++ b/addon/mixins/popover.js
@@ -42,9 +42,11 @@ export default Ember.Mixin.create(StyleBindingsMixin, BodyEventListener, {
   }).property('contentViewClass'),
   didInsertElement: function() {
     this._super();
-    this.snapToPosition();
-    this.set('visibility', 'visible');
-    return this.set('isShowing', true);
+    Ember.run.schedule('afterRender', this, () => {
+      this.snapToPosition();
+      this.set('visibility', 'visible');
+      this.set('isShowing', true);
+    });
   },
   willDestroyElement: function() {
     this.$().off($.support.transition.end);

--- a/addon/views/multi-select-option.js
+++ b/addon/views/multi-select-option.js
@@ -6,13 +6,13 @@ export default Ember.View.extend({
   classNames: 'ember-select-search-choice',
   didInsertElement: function() {
     this._super();
-    return this.labelPathDidChange();
+    this.labelPathDidChange();
   },
-  labelPathDidChange: Ember.observer(function() {
+  labelPathDidChange: Ember.observer('content', 'labelPath', function() {
     var labelPath, path;
     labelPath = this.get('labelPath');
     path = labelPath ? "content." + labelPath : 'content';
     Ember.defineProperty(this, 'label', Ember.computed.alias(path));
-    return this.notifyPropertyChange('label');
-  }, 'content', 'labelPath')
+    this.notifyPropertyChange('label');
+  })
 });

--- a/addon/views/select-option.js
+++ b/addon/views/select-option.js
@@ -14,7 +14,7 @@ export default Ember.View.extend({
   isHighlighted: Ember.computed(function() {
     return this.get('highlighted') === this.get('content');
   }).property('highlighted', 'content'),
-  labelPathDidChange: Ember.on('init', Ember.observer(function() {
+  labelPathDidChange: Ember.on('init', Ember.observer('content', 'labelPath', function() {
     var labelPath, path;
     labelPath = this.get('labelPath');
 
@@ -26,7 +26,7 @@ export default Ember.View.extend({
     // 'context.#{labelPath}'
     Ember.defineProperty(this, 'label', Ember.computed.alias(path));
     return this.notifyPropertyChange('label');
-  }, 'content', 'labelPath')),
+  })),
   processDropDownShown: function() {
     return this.get('selectComponent').send('hideDropdown');
   },

--- a/app/templates/color-picker-dropdown.hbs
+++ b/app/templates/color-picker-dropdown.hbs
@@ -1,5 +1,5 @@
 <div class="dropdown open">
-  <div {{bind-attr class=":dropdown-menu :color-picker-dropdown dropdownClass"}}
+  <div class="dropdown-menu color-picker-dropdown {{dropdownClass}}"
     role="menu" aria-labelledby="dLabel">
     {{#each row in colorRows}}
       <div class="color-row clearfix">
@@ -14,11 +14,11 @@
       <hr>
     {{/each}}
       <form {{action "setCustomColor" on="submit"}}
-      {{bind-attr class=":color-picker-custom-form isCustomColorValid:valid:invalid"}}>
+      class="color-picker-custom-form {{if isCustomColorValid 'valid' 'invalid'}}">
         <div class="input-group">
-          <span {{bind-attr class=":input-group-addon
-            :color-picker-custom-preview isCustomColor:active"
-            style="customColorCSS"}} {{action "setCustomColor"}}>
+          <span class="input-group-addon
+            color-picker-custom-preview {{if isCustomColor 'active'}}"
+            style={{customColorCSS}} {{action "setCustomColor"}}>
           </span>
           {{input valueBinding="customColor"
             class="form-control input-sm"

--- a/app/templates/font-chooser-item.hbs
+++ b/app/templates/font-chooser-item.hbs
@@ -1,3 +1,3 @@
-<div {{bind-attr style="view.style"}}>
+<div style={{view.style}}>
   {{view.label}}
 </div>

--- a/app/templates/modal-footer.hbs
+++ b/app/templates/modal-footer.hbs
@@ -1,6 +1,6 @@
 {{#if confirmText}}
   <button type="button"
-    {{bind-attr class=":btn :btn-primary :btn-confirm isDisabled:disabled" disabled="isDisabled"}}
+    class="btn btn-primary btn-confirm {{if isDisabled 'disabled'}}" disabled={{isDisabled}}
     {{action 'sendConfirm'}}>{{confirmText}}
   </button>
 {{/if}}

--- a/app/templates/modal.hbs
+++ b/app/templates/modal.hbs
@@ -1,4 +1,4 @@
-<div {{bind-attr class=":modal-dialog sizeClass"}} tabindex="-1">
+<div class="modal-dialog {{sizeClass}}" tabindex="-1">
   <div class="modal-content">
     <div class="modal-header {{headerClass}}">
       {{view _headerViewClass}}

--- a/app/templates/multi-select.hbs
+++ b/app/templates/multi-select.hbs
@@ -1,5 +1,5 @@
-<div {{bind-attr class=":ember-select-container :ember-select-multi :dropdown-toggle :js-dropdown-toggle hasFocus:ember-select-focus"}}>
-  <ul {{bind-attr class=":ember-select-choices choicesFieldClass"}}>
+<div class="ember-select-container ember-select-multi dropdown-toggle js-dropdown-toggle {{if hasFocus 'ember-select-focus'}}">
+  <ul class="ember-select-choices {{choicesFieldClass}}">
     {{#each selections as |item|}}
       {{view selectionItemView
         content=item

--- a/app/templates/popover-link-popover.hbs
+++ b/app/templates/popover-link-popover.hbs
@@ -1,4 +1,4 @@
-<div class="arrow" {{bind-attr style="view.arrowStyle"}}></div>
+<div class="arrow" style={{view.arrowStyle}}></div>
 {{#if title}}
   <h4 class="popover-title">{{title}}</h4>
 {{/if}}

--- a/app/templates/popover.hbs
+++ b/app/templates/popover.hbs
@@ -1,4 +1,4 @@
-<div class="arrow" {{bind-attr style="arrowStyle"}}></div>
+<div class="arrow" style={{arrowStyle}}></div>
 {{#if title}}
   <h4 class="popover-title">{{title}}</h4>
 {{/if}}

--- a/app/templates/select-item-layout.hbs
+++ b/app/templates/select-item-layout.hbs
@@ -4,7 +4,7 @@
   </div>
 {{else}}
   {{#if view.titleOnOptions}}
-    <span {{bind-attr title=view.label}}>
+    <span title={{view.label}}>
       {{view.label}}
     </span>
   {{else}}

--- a/app/templates/select-item.hbs
+++ b/app/templates/select-item.hbs
@@ -1,5 +1,5 @@
 {{#if view.titleOnOptions}}
-  <span {{bind-attr title=view.label}}>
+  <span title={{view.label}}>
     {{view.label}}
   </span>
 {{else}}

--- a/app/templates/select.hbs
+++ b/app/templates/select.hbs
@@ -1,16 +1,16 @@
 <div class="ember-select-container dropdown-toggle js-dropdown-toggle" {{action "toggleDropdown"}}>
-  <a {{bind-attr class=":form-control :ember-select-choice buttonClass disabled:disabled
-  hasFocus:ember-select-focus"}}>
+  <a class="form-control ember-select-choice {{buttonClass}} {{if disabled 'disabled'}}
+  {{if hasFocus 'ember-select-focus'}}">
     {{#if selection}}
       {{view selectedItemView content=selection selectComponent=this}}
-      <i {{bind-attr class=view.dropdownToggleIcon}}></i>
+      <i class={{view.dropdownToggleIcon}}></i>
     {{else}}
       <span>{{prompt}}</span>
-      <i {{bind-attr class=view.dropdownToggleIcon}}></i>
+      <i class={{view.dropdownToggleIcon}}></i>
     {{/if}}
   </a>
 </div>
-<div {{bind-attr class=":dropdown-menu :js-dropdown-menu dropdownMenuClass isDropdownMenuPulledRight:pull-right"}}>
+<div class="dropdown-menu js-dropdown-menu {{dropdownMenuClass}} {{if isDropdownMenuPulledRight 'pull-right'}}">
   {{#unless isSelect}}
     <div class="ember-select-search">
       {{view searchView selectComponent=this}}

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-widgets",
   "dependencies": {
-    "ember": "1.11.4",
+    "ember": "~1.13.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-resolver": "~0.1.15",
     "handlebars": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "~2.16.2",
     "ember-cli-dependency-checker": "^2.0.0",
+    "ember-cli-deprecation-workflow": "^1.0.1",
     "ember-cli-htmlbars": "~2.0.3",
     "ember-cli-htmlbars-inline-precompile": "~1.0.2",
     "ember-cli-inject-live-reload": "^1.4.1",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import Resolver from 'ember/resolver';
+import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 import CarouselItem from 'ember-widgets/views/carousel-item';
@@ -15,7 +15,7 @@ App = Ember.Application.extend({
 });
 
 // Legacy view-as-component weirdness. Don't ever ever ever do this.
-Ember.Handlebars.helper('carousel-item', CarouselItem);
+Ember.Helper.helper('carousel-item', CarouselItem);
 
 loadInitializers(App, config.modulePrefix);
 

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
-import CarouselItem from 'ember-widgets/views/carousel-item';
 
 var App;
 
@@ -13,9 +12,6 @@ App = Ember.Application.extend({
   podModulePrefix: config.podModulePrefix,
   Resolver: Resolver
 });
-
-// Legacy view-as-component weirdness. Don't ever ever ever do this.
-Ember.Helper.helper('carousel-item', CarouselItem);
 
 loadInitializers(App, config.modulePrefix);
 

--- a/tests/dummy/app/templates/ember-widgets/carousel.hbs
+++ b/tests/dummy/app/templates/ember-widgets/carousel.hbs
@@ -6,15 +6,15 @@
 
       <div class="example-container">
         {{#carousel-component}}
-          {{#carousel-item class="active"}}
+          {{#view 'carousel-item' class="active"}}
             <img src="img/bootstrap-mdo-sfmoma-01.jpg" alt="">
-          {{/carousel-item}}
-          {{#carousel-item}}
+          {{/view}}
+          {{#view 'carousel-item'}}
             <img src="img/bootstrap-mdo-sfmoma-02.jpg" alt="">
-          {{/carousel-item}}
-          {{#carousel-item}}
+          {{/view}}
+          {{#view 'carousel-item'}}
             <img src="img/bootstrap-mdo-sfmoma-03.jpg" alt="">
-          {{/carousel-item}}
+          {{/view}}
         {{/carousel-component}}
       </div>
     </div>
@@ -22,7 +22,7 @@
     <div class="col-md-12 bumper-30">
       <h4>Application.hbs</h4>
       <div class="highlight">
-<pre class="prettyprint lang-html">&#123;&#123;#carousel-group&#125;&#125;<br/>  &#123;&#123;#carousel-item class=&quot;active&quot;&#125;&#125;<br/>    &lt;img src=&quot;/gh_pages/img/bootstrap-mdo-sfmoma-01.jpg&quot; alt=&quot;&quot;&gt;<br/>  &#123;&#123;/carousel-item&#125;&#125;<br/>  &#123;&#123;#carousel-item&#125;&#125;<br/>    &lt;img src=&quot;/gh_pages/img/bootstrap-mdo-sfmoma-02.jpg&quot; alt=&quot;&quot;&gt;<br/>  &#123;&#123;/carousel-item&#125;&#125;<br/>  &#123;&#123;#carousel-item&#125;&#125;<br/>    &lt;img src=&quot;/gh_pages/img/bootstrap-mdo-sfmoma-03.jpg&quot; alt=&quot;&quot;&gt;<br/>  &#123;&#123;/carousel-item&#125;&#125;<br/>&#123;&#123;/carousel-group&#125;&#125;</pre>
+<pre class="prettyprint lang-html">&#123;&#123;#carousel-group&#125;&#125;<br/>  &#123;&#123;#view &quot;carousel-item&quot; class=&quot;active&quot;&#125;&#125;<br/>    &lt;img src=&quot;/gh_pages/img/bootstrap-mdo-sfmoma-01.jpg&quot; alt=&quot;&quot;&gt;<br/>  &#123;&#123;/view&#125;&#125;<br/>  &#123;&#123;#view &quot;carousel-item&quot;&#125;&#125;<br/>    &lt;img src=&quot;/gh_pages/img/bootstrap-mdo-sfmoma-02.jpg&quot; alt=&quot;&quot;&gt;<br/>  &#123;&#123;/view&#125;&#125;<br/>  &#123;&#123;#view &quot;carousel-item&quot;&#125;&#125;<br/>    &lt;img src=&quot;/gh_pages/img/bootstrap-mdo-sfmoma-03.jpg&quot; alt=&quot;&quot;&gt;<br/>  &#123;&#123;/view&#125;&#125;<br/>&#123;&#123;/carousel-group&#125;&#125;</pre>
       </div>
     </div>
   </div>

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -1,5 +1,6 @@
 self.deprecationWorkflow = self.deprecationWorkflow || {};
 self.deprecationWorkflow.config = {
+  throwOnUnhandled: true,
   workflow: [
     { handler: "silence", matchMessage: "Global lookup of Ember from a Handlebars template is deprecated." },
     { handler: "silence", matchId: "ember-views.collection-view-deprecated" },

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -5,7 +5,6 @@ self.deprecationWorkflow.config = {
     { handler: "silence", matchMessage: "Global lookup of Ember from a Handlebars template is deprecated." },
     { handler: "silence", matchId: "ember-views.collection-view-deprecated" },
     { handler: "silence", matchId: "ember-views.dispatching-modify-property" },
-    { handler: "silence", matchMessage: "Passing the dependentKeys after the callback function in Ember.observer is deprecated. Ensure the callback function is the last argument." },
     { handler: "silence", matchId: "ember-views.view-deprecated" },
     { handler: "silence", matchId: "ember-views.container-view" },
     { handler: "silence", matchMessage: "Setting `childViews` on a Container is deprecated." },

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -9,7 +9,6 @@ self.deprecationWorkflow.config = {
     { handler: "silence", matchId: "ember-views.container-view" },
     { handler: "silence", matchMessage: "Setting `childViews` on a Container is deprecated." },
     { handler: "silence", matchId: "ember-test-helpers.test-module-for-component.test-type" },
-    // { handler: "silence", matchMessage: "Using the same function as getter and setter is deprecated." },
     { handler: "silence", matchMessage: "Using deprecated `template` property on a View." }
   ]
 };

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -1,0 +1,15 @@
+self.deprecationWorkflow = self.deprecationWorkflow || {};
+self.deprecationWorkflow.config = {
+  workflow: [
+    { handler: "silence", matchMessage: "Global lookup of Ember from a Handlebars template is deprecated." },
+    { handler: "silence", matchId: "ember-views.collection-view-deprecated" },
+    { handler: "silence", matchId: "ember-views.dispatching-modify-property" },
+    { handler: "silence", matchMessage: "Passing the dependentKeys after the callback function in Ember.observer is deprecated. Ensure the callback function is the last argument." },
+    { handler: "silence", matchId: "ember-views.view-deprecated" },
+    { handler: "silence", matchId: "ember-views.container-view" },
+    { handler: "silence", matchMessage: "Setting `childViews` on a Container is deprecated." },
+    { handler: "silence", matchId: "ember-test-helpers.test-module-for-component.test-type" },
+    // { handler: "silence", matchMessage: "Using the same function as getter and setter is deprecated." },
+    { handler: "silence", matchMessage: "Using deprecated `template` property on a View." }
+  ]
+};

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -8,7 +8,6 @@ self.deprecationWorkflow.config = {
     { handler: "silence", matchId: "ember-views.view-deprecated" },
     { handler: "silence", matchId: "ember-views.container-view" },
     { handler: "silence", matchMessage: "Setting `childViews` on a Container is deprecated." },
-    { handler: "silence", matchId: "ember-test-helpers.test-module-for-component.test-type" },
     { handler: "silence", matchMessage: "Using deprecated `template` property on a View." }
   ]
 };

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember/resolver';
+import Resolver from 'ember-resolver';
 import config from '../../config/environment';
 
 var resolver = Resolver.create();

--- a/tests/integration/color-picker-test.js
+++ b/tests/integration/color-picker-test.js
@@ -101,7 +101,7 @@ test('Custom color is set as selected color', function(assert) {
   var customColor;
   colorPicker = this.subject();
   customColor = '#addec0';
-  this.append();
+  this.render();
   openColorChooser();
   fillInCustomColor(customColor);
   click(getPreviewCellSelector());
@@ -118,7 +118,7 @@ test('Test accepting custom color without hashtag', function(assert) {
   colorPicker = this.subject();
   customColor = 'addec0';
   formattedCustomColor = '#addec0';
-  this.append();
+  this.render();
   openColorChooser();
   fillInCustomColor(customColor);
   click(getPreviewCellSelector());
@@ -134,7 +134,7 @@ test('Selecting a color should send an action', function(assert) {
   customColor = '#addec0';
   color = '#01FF70';
   spy = sinon.spy(colorPicker, 'sendAction');
-  this.append();
+  this.render();
   selectColor(color);
   andThen(function() {
     return assert.ok(spy.calledWithExactly('userSelected', color), 'Clicking color picker cell sends action');
@@ -149,7 +149,7 @@ test('Selecting a color should send an action', function(assert) {
 
 test('Click outside of the component should close the dropdown', function(assert) {
   colorPicker = this.subject();
-  this.append();
+  this.render();
   openColorChooser();
   return andThen(function() {
     $('body').trigger('click');
@@ -161,7 +161,7 @@ test('Submitting custom color form updates color and does not reload page', func
   var customColor;
   colorPicker = this.subject();
   customColor = "#abc123";
-  this.append();
+  this.render();
   openColorChooser();
   fillInCustomColor(customColor);
   return andThen(function() {
@@ -174,7 +174,7 @@ test('Transparent color is set in preview cell', function(assert) {
   var color;
   colorPicker = this.subject();
   color = 'transparent';
-  this.append();
+  this.render();
   selectColor(color);
   return andThen(function() {
     return assert.ok(colorPicker.get('isColorTransparent'), 'Transparent color correctly identified in preview cell');
@@ -185,7 +185,7 @@ test('Correct cell is highlighted within color palette', function(assert) {
   var color;
   colorPicker = this.subject();
   color = '#01FF70';
-  this.append();
+  this.render();
   selectColor(color);
   openColorChooser();
   return andThen(function() {

--- a/tests/integration/debounced-text-component-test.js
+++ b/tests/integration/debounced-text-component-test.js
@@ -1,37 +1,24 @@
-import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
-import startApp from '../helpers/start-app';
-
-var debouncedComponent, app;
+import wait from 'ember-test-helpers/wait';
 
 moduleForComponent('debounced-text-component', '[Integration] Debounced Text Component', {
-  setup: function() {
-    app = startApp();
-    window.EMBER_WIDGETS_DISABLE_ANIMATIONS = true;
-  },
-  teardown: function() {
-    Ember.run(function() {
-      debouncedComponent.destroy();
-    });
-    Ember.run(app, 'destroy');
-    window.EMBER_WIDGETS_DISABLE_ANIMATIONS = false;
-  }
+  integration: true,
 });
 
 test('Test debounced text', function(assert) {
-  var spy;
-
   assert.expect(1);
 
-  debouncedComponent = this.subject();
-  spy = sinon.spy(debouncedComponent, "sendAction");
-
-  debouncedComponent.onValueChanged('fo');
-  debouncedComponent.onValueChanged('foo');
-  wait();
-
-  andThen(function() {
-    assert.ok(spy.calledWithExactly('valueChanged', 'foo'),
-      'valueChanged action is fired when value changed');
+  this.on('valueChanged', (newText) => {
+    assert.equal(newText, 'foo',
+      'valueChanged action is fired once when value changed');
   });
+
+  this.render(hbs`{{debounced-text-component valueChanged='valueChanged'}}`);
+
+  this.$('input').val('fo');
+  this.$('input').change();
+  this.$('input').val('foo');
+  this.$('input').change();
+  return wait();
 });

--- a/tests/integration/modal-component-test.js
+++ b/tests/integration/modal-component-test.js
@@ -27,7 +27,7 @@ test('With DISABLE_ANIMATIONS=true, hide can be called several times', function(
   assert.expect(1);
   window.EMBER_WIDGETS_DISABLE_ANIMATIONS = true;
   modal = this.subject();
-  this.append();
+  this.render();
   return andThen(function() {
     modal.hide();
     modal.hide();
@@ -39,7 +39,7 @@ test('Test tab loop only inside modal', function(assert) {
   var buttonCancel, buttonConfirm, modalComponent, validateFocus;
   assert.expect(3);
   modal = this.subject();
-  this.append();
+  this.render();
   modalComponent = modal.$();
   modal.set('enforceModality', true);
   buttonConfirm = find('.btn-confirm', modalComponent);
@@ -66,7 +66,7 @@ test('Test preserving the focus when clicking on non-focusable element', functio
   var buttonCancel, buttonConfirm, modalBody, modalComponent, validateFocus;
   assert.expect(1);
   modal = this.subject();
-  this.append();
+  this.render();
   modalComponent = modal.$();
   buttonConfirm = find('.btn-confirm', modalComponent);
   buttonCancel = find('.btn-cancel', modalComponent);
@@ -89,7 +89,7 @@ test('Test pressing Enter to confirm', function(assert) {
     enterToConfirm: true
   });
   spy = sinon.spy(modal, "send");
-  this.append();
+  this.render();
   modalComponent = modal.$();
   keyEvent(modalComponent, 'keydown', 13);
   return andThen(function() {

--- a/tests/integration/multi-select-component-test.js
+++ b/tests/integration/multi-select-component-test.js
@@ -90,7 +90,7 @@ test('Test keyboard and mouse interaction', function(assert) {
   multiSelect = this.subject({
     content: ['foo', 'bar', 'barca', 'baz']
   });
-  this.append();
+  this.render();
   multiSelectComponent = multiSelect.$();
   highlightedComponent = find('.ember-select-multi', multiSelectComponent);
   textField = find('.ember-text-field', multiSelectComponent);
@@ -182,7 +182,7 @@ test("Can add item via click", function(assert) {
     optionValuePath: 'code',
     classNames: 'some-class-name'
   });
-  this.append();
+  this.render();
   $multiSelect = find('.some-class-name');
   return selectInMultiChosen($multiSelect, 'Alice').then(function() {
     $multiSelect = find('.some-class-name');
@@ -200,7 +200,7 @@ test("Invalid item cannot be selected", function(assert) {
     optionValuePath: 'code',
     classNames: 'some-class-name'
   });
-  this.append();
+  this.render();
   $multiSelect = find('.some-class-name');
   userDidSelectStub = sinon.stub(multiSelect, 'userDidSelect');
   return item = findInMultiChosen($multiSelect, 'textThatWontMatch').then(function(item) {
@@ -224,7 +224,7 @@ test("Valid item can be selected via enter", function(assert) {
     optionValuePath: 'code',
     classNames: 'some-class-name'
   });
-  this.append();
+  this.render();
   $multiSelect = find('.some-class-name');
   userDidSelectStub = sinon.stub(multiSelect, 'userDidSelect');
   return item = findInMultiChosen($multiSelect, 'Alice').then(function(item) {

--- a/tests/integration/popover-link-component-test.js
+++ b/tests/integration/popover-link-component-test.js
@@ -34,7 +34,7 @@ test('Destroying a popover link destroys the associated popover', function(asser
   popoverLink = this.subject({
     rootElement: "#ember-testing"
   });
-  this.append();
+  this.render();
   click('.popover-link');
   andThen(function() {
     var popover;
@@ -56,7 +56,7 @@ test('Popover links can be configured to be opened with left clicks', function(a
     rootElement: "#ember-testing",
     openOnLeftClick: true
   });
-  this.append();
+  this.render();
   click('.popover-link');
   return andThen(function() {
     return assert.ok(isPresent('.popover'), "The popover is created");
@@ -69,7 +69,7 @@ test('Popover links can be configured to not be opened with left clicks', functi
     rootElement: "#ember-testing",
     openOnLeftClick: false
   });
-  this.append();
+  this.render();
   click('.popover-link');
   return andThen(function() {
     return assert.ok(isNotPresent('.popover'), "The popover is not created");
@@ -82,7 +82,7 @@ test('Popover links can be configured to be opened with right clicks', function(
     rootElement: "#ember-testing",
     openOnRightClick: true
   });
-  this.append();
+  this.render();
   triggerEvent('.popover-link', 'contextmenu');
   return andThen(function() {
     return assert.ok(isPresent('.popover'), "The popover is created");
@@ -95,7 +95,7 @@ test('Popover links can be configured to not be opened with right clicks', funct
     rootElement: "#ember-testing",
     openOnRightClick: false
   });
-  this.append();
+  this.render();
   triggerEvent('.popover-link', 'contextmenu');
   return andThen(function() {
     return assert.ok(isNotPresent('.popover'), "The popover is not created");
@@ -109,7 +109,7 @@ test('Popover links do not bubble left click events when configured to open with
     openOnLeftClick: true,
     _openPopover: Ember.K
   });
-  this.append();
+  this.render();
   bubbled = Ember.run(popoverLink, 'click');
   return assert.ok(!bubbled, 'The event did not bubble');
 });
@@ -121,7 +121,7 @@ test('Popover links bubble left click events when not configured to open with le
     openOnLeftClick: false,
     _openPopover: Ember.K
   });
-  this.append();
+  this.render();
   bubbled = Ember.run(popoverLink, 'click');
   return assert.ok(bubbled, 'The event bubbled');
 });
@@ -133,7 +133,7 @@ test('Popover links do not bubble right click events when configured to open wit
     openOnRightClick: true,
     _openPopover: Ember.K
   });
-  this.append();
+  this.render();
   bubbled = Ember.run(popoverLink, 'contextMenu');
   return assert.ok(!bubbled, 'The event did not bubble');
 });
@@ -145,7 +145,7 @@ test('Popover links bubble right click events when not configured to open with r
     openOnRightClick: false,
     _openPopover: Ember.K
   });
-  this.append();
+  this.render();
   bubbled = Ember.run(popoverLink, 'contextMenu');
   return assert.ok(bubbled, 'The event bubbled');
 });
@@ -159,7 +159,7 @@ test('Popover links can be configured to hide other popovers when opening', func
     rootElement: "#ember-testing",
     hideOthers: true
   });
-  this.append();
+  this.render();
   click('.popover-link');
   andThen(function() {
     return assert.ok(isPresent('.popover'), "The new popover was not hidden");
@@ -178,7 +178,7 @@ test('Popover links can be configured to not hide other popovers when opening', 
     rootElement: "#ember-testing",
     hideOthers: false
   });
-  this.append();
+  this.render();
   click('.popover-link');
   andThen(function() {
     return assert.ok(isPresent('.popover'), "The new popover was not hidden");

--- a/tests/integration/select-component-test.js
+++ b/tests/integration/select-component-test.js
@@ -100,7 +100,7 @@ test('Test keyboard interaction', function(assert) {
   select = this.subject({
     content: ['foo', 'bar', 'barca', 'baz']
   });
-  this.append();
+  this.render();
   selectComponent = select.$();
   validateDropdownVisible = function(messageVisible) {
     return assert.ok(isVisible('.ember-select-results', selectComponent), messageVisible);
@@ -154,7 +154,7 @@ test('Test query highlighting', function(assert) {
   select = this.subject({
     content: ['aaa', 'bar', 'barca', 'baz']
   });
-  this.append();
+  this.render();
   let selectComponent = select.$();
   selectComponent.focus();
 
@@ -232,7 +232,7 @@ test('Test userSelected action', function(assert) {
     content: ['bar', 'baz']
   });
   spy = sinon.spy(select, "sendAction");
-  this.append();
+  this.render();
   selectElement = select.$();
   openDropdown(selectElement);
   andThen(function() {
@@ -256,7 +256,7 @@ test('Test valueChanged action when dropdown is closed and query is cleared', fu
     content: ['bar', 'baz']
   });
   const spy = sinon.spy(select, 'sendAction');
-  this.append();
+  this.render();
 
   const selectElement = select.$();
   const searchInput = find('input', selectElement);
@@ -325,7 +325,7 @@ test("Show empty content view if content is empty", function(assert) {
     optionValuePath: 'code',
     classNames: 'select-class-name'
   });
-  this.append();
+  this.render();
   selectElement = select.$();
   openDropdown(selectElement);
   andThen(function() {
@@ -367,7 +367,7 @@ test("Show no-result message if has content but filtered content is empty", func
     optionLabelPath: 'name',
     classNames: 'select-class-name'
   });
-  this.append();
+  this.render();
   selectElement = select.$();
   openDropdown(selectElement);
   return andThen(function() {
@@ -393,7 +393,7 @@ test('optionValuePath with POJOs', function(assert) {
     optionLabelPath: 'name',
     optionValuePath: 'value'
   });
-  this.append();
+  this.render();
   Ember.run(function() {
     select.set('value', 2);
   });
@@ -423,7 +423,7 @@ test('optionValuePath with Ember Objects', function(assert) {
     optionLabelPath: 'name',
     optionValuePath: 'value'
   });
-  this.append();
+  this.render();
   Ember.run(function() {
     select.set('value', 2);
   });
@@ -454,7 +454,7 @@ test('optionValuePath with ArrayProxy', function(assert) {
     optionLabelPath: 'name',
     optionValuePath: 'value'
   });
-  this.append();
+  this.render();
   Ember.run(function() {
     select.set('value', 2);
   });
@@ -482,7 +482,7 @@ test('optionValuePath with nested valuePath', function(assert) {
     optionLabelPath: 'name',
     optionValuePath: 'value.subvalue'
   });
-  this.append();
+  this.render();
   Ember.run(function() {
     select.set('value', 2);
   });
@@ -518,7 +518,7 @@ test('Can specify a custom component with tabComponentName', function(assert) {
   select = this.subject({
     content: ['dummy data'],
   });
-  this.append();
+  this.render();
   let selectElement = select.$();
 
   openDropdown(selectElement);
@@ -543,7 +543,7 @@ test('Specified dropdownMenuClass is used when the dropdown is opened', function
     content: ['dummy data'],
     dropdownMenuClass: cssClassName
   });
-  this.append();
+  this.render();
   var selectElement = select.$();
   openDropdown(selectElement);
   return andThen(function() {
@@ -563,7 +563,7 @@ test('Can specify a custom partial with listViewPartial', function(assert) {
     content: ['dummy data'],
     listViewPartial: 'custom-list-view-partial'
   });
-  this.append();
+  this.render();
   var selectElement = select.$();
   openDropdown(selectElement);
   return andThen(function() {
@@ -580,7 +580,7 @@ test('Select handles a change in the content array properly', function(assert) {
   select = this.subject({
     content: ['test content']
   });
-  this.append();
+  this.render();
   var selectElement = select.$();
   openDropdown(selectElement);
   andThen(function() {
@@ -603,7 +603,7 @@ test('Selected option is visible when dropdown is opened', function(assert) {
     selection,
     dropdownHeight: 30
   });
-  this.append();
+  this.render();
   // The highlighted property is set when the user hovers over the select field
   // Lets programatically set it after rendering to emulate that behavior.
   andThen(() => select.set('highlighted', selection));
@@ -625,7 +625,7 @@ test('Selected object option is visible when dropdown is opened', function(asser
     optionLabelPath: 'key',
     dropdownHeight: 30
   });
-  this.append();
+  this.render();
   var selectElement = select.$();
   // The highlighted property is set when the user hovers over the select field
   // Lets programatically set it after rendering to emulate that behavior.
@@ -647,7 +647,7 @@ test('Selected option is not visible when shouldEnsureVisible is false', functio
     shouldEnsureVisible: false,
     dropdownHeight: 30
   });
-  this.append();
+  this.render();
   // The highlighted property is set when the user hovers over the select field
   // Lets programatically set it after rendering to emulate that behavior.
   andThen(() => select.set('highlighted', selection));
@@ -667,7 +667,7 @@ test('Dropdown does not open on key event when select is disabled', function(ass
     selection: 'foo',
     disabled: true
   });
-  this.append();
+  this.render();
 
   var selectElement = select.$();
   selectElement.focus();
@@ -701,7 +701,7 @@ test('Collapsed group can be expanded, collapsed', function(assert) {
     isGroupHeaderCollapsible: true,
     collapsedGroupHeaders: Ember.A(['Squawk', 'bark'])
   });
-  this.append();
+  this.render();
 
   var selectElement = select.$();
   openDropdown(selectElement);

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,7 @@
 import resolver from './helpers/resolver';
 import {
   setResolver
-} from 'ember-qunit';
+} from '@ember/test-helpers';
 import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2419,6 +2419,16 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
+broccoli-plugin@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz#a26315732fb99ed2d9fb58f12a1e14e986b4fabd"
+  integrity sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==
+  dependencies:
+    promise-map-series "^0.2.1"
+    quick-temp "^0.1.3"
+    rimraf "^2.3.4"
+    symlink-or-copy "^1.1.8"
+
 broccoli-rollup@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-2.1.0.tgz#94d703625c24dbad2e57789508f63ccfcbb13c00"
@@ -3628,6 +3638,16 @@ ember-cli-dependency-checker@^2.0.0:
     resolve "^1.5.0"
     semver "^5.3.0"
 
+ember-cli-deprecation-workflow@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-1.0.1.tgz#3305a6879af7f074216a54963d92491c411ce7e0"
+  integrity sha512-tns8l4FLz8zmhmNRH7ywihs4XNTTuQysl+POYTpiyjb4zPNKv0cUJBCT/MklYFWBCo/5DcVzabhLODJZcScUfg==
+  dependencies:
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^3.0.1"
+    broccoli-plugin "^1.3.1"
+    ember-debug-handlers-polyfill "^1.1.1"
+
 ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
@@ -3898,6 +3918,11 @@ ember-compatibility-helpers@^1.0.0:
     babel-plugin-debug-macros "^0.2.0"
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
+
+ember-debug-handlers-polyfill@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ember-debug-handlers-polyfill/-/ember-debug-handlers-polyfill-1.1.1.tgz#e9ae0a720271a834221179202367421b580002ef"
+  integrity sha512-lO7FBAqJjzbL+IjnWhVfQITypPOJmXdZngZR/Vdn513W4g/Q6Sjicao/mDzeDCb48Y70C4Facwk0LjdIpSZkRg==
 
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"


### PR DESCRIPTION
Add `ember-cli-deprecation-workflow` to silence known deprecations.

Also update default to Ember 1.13.

The remaining deprecations are mostly linked to `Ember.View`.