### PR TITLE
[CHORE] Remove warning around style binding

### DIFF
--- a/addon/components/color-picker-dropdown.js
+++ b/addon/components/color-picker-dropdown.js
@@ -64,7 +64,7 @@ export default Ember.Component.extend(BodyEventListenerMixin, ColorPickerMixin, 
     return /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(this.get('formattedCustomColor'));
   }).property('formattedCustomColor'),
   customColorCSS: Ember.computed(function() {
-    return "background-color: " + (this.get('formattedCustomColor'));
+    return Ember.String.htmlSafe("background-color: " + (this.get('formattedCustomColor')));
   }).property('formattedCustomColor'),
   userDidSelect: function(selection) {
     return this.sendAction('userSelected', selection);

--- a/addon/mixins/popover.js
+++ b/addon/mixins/popover.js
@@ -183,11 +183,11 @@ export default Ember.Mixin.create(StyleBindingsMixin, BodyEventListener, {
     }
     this.correctIfOffscreen();
     if (!Ember.isEmpty($target)) {
-      return this.positionArrow();
+      this.positionArrow();
     }
   },
   positionArrow: function() {
-    var $target, arrowSize, left, pos, top;
+    var $target, arrowSize, left, pos, top, arrowStyle;
     $target = $(this.get('targetElement'));
     pos = this.getOffset($target);
     pos.width = $target[0].offsetWidth;
@@ -197,12 +197,13 @@ export default Ember.Mixin.create(StyleBindingsMixin, BodyEventListener, {
       case 'left':
       case 'right':
         top = pos.top + pos.height / 2 - this.get('top') - arrowSize / 2;
-        return this.set('arrowStyle', 'margin-top:' + top + 'px;');
+        arrowStyle = 'margin-top:' + top + 'px;';
       case 'top':
       case 'bottom':
         left = pos.left + pos.width / 2 - this.get('left') - arrowSize / 2;
-        return this.set('arrowStyle', 'margin-left:' + left + 'px;');
+        arrowStyle = 'margin-left:' + left + 'px;';
     }
+    this.set('arrowStyle', Ember.String.htmlSafe(arrowStyle));
   },
   correctIfOffscreen: function() {
     var actualHeight, actualWidth, bodyHeight, bodyWidth;

--- a/addon/mixins/style-bindings.js
+++ b/addon/mixins/style-bindings.js
@@ -42,7 +42,7 @@ export default Ember.Mixin.create({
        });
        styleString = styleTokens.join('');
        if (styleString.length !== 0) {
-         return styleString;
+         return Ember.String.htmlSafe(styleString);
        }
      };
    })(this));

--- a/app/templates/font-chooser-item.hbs
+++ b/app/templates/font-chooser-item.hbs
@@ -1,3 +1,0 @@
-<div style={{view.style}}>
-  {{view.label}}
-</div>


### PR DESCRIPTION
`WARNING: Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that values being bound are properly escaped. For more information, including how to disable this warning, see http://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes.`

Also remove the `footer-chooser-item` template which was used by the text editor introduced in c265d6c
This component has been removed in #179