### PR TITLE
Avoid state change during rendering

### DIFF
--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -674,16 +674,16 @@ export default Ember.Component.extend(
     return this.sendAction('userSelected', selection);
   },
 
-  focusIn: function() {
-    Ember.run.schedule('actions', () => {
+  focusIn: function(event) {
+    if (event.target.tagName === 'INPUT') {
       this.set('hasFocus', true);
-    });
+    }
   },
 
-  focusOut: function() {
-    Ember.run.schedule('actions', () => {
+  focusOut: function(event) {
+    if (event.target.tagName === 'INPUT') {
       this.set('hasFocus', false);
-    });
+    }
   },
 
   actions: {

--- a/addon/mixins/popover.js
+++ b/addon/mixins/popover.js
@@ -42,7 +42,7 @@ export default Ember.Mixin.create(StyleBindingsMixin, BodyEventListener, {
   }).property('contentViewClass'),
   didInsertElement: function() {
     this._super();
-    Ember.run.schedule('actions', this, () => {
+    Ember.run.schedule('afterRender', () => {
       this.snapToPosition();
       this.set('visibility', 'visible');
       this.set('isShowing', true);


### PR DESCRIPTION
* focus events may fire from child elements (like buttons) may fire
  during teardown of the DOM (un-rendering). These should be ignored
  by a parent component which only cared about input focus anyway.
* Move work in the popover out of `didInsertElement` and into the
  `afterRender` queue.