### PR TITLE
Ignore resize events that aren't on window

### DIFF
--- a/addon/mysterious-dependency/ember-addepar-mixins/resize_handler.js
+++ b/addon/mysterious-dependency/ember-addepar-mixins/resize_handler.js
@@ -21,6 +21,11 @@ AddeparMixins.ResizeHandlerMixin = Ember.Mixin.create({
     };
   }),
   handleWindowResize: function(event) {
+    // Ignore bubbled "resize" events. These can come from other jquery
+    // libraries, eg jquery-ui's "resizable" widget
+    if (event.target !== window) {
+      return;
+    }
     if (!this.get('resizing')) {
       this.set('resizing', true);
       if (typeof this.onResizeStart === "function") {


### PR DESCRIPTION
We've noticed excessive "resize" events in some app usage that came when jquery-ui.resizable was in use on the page. Because these event handlers are added with jQuery, the ["resize" events](https://api.jqueryui.com/resizable/#event-resize) that resizable fires will be bubbled to the window.

This results in a lot of unnecessary work — the select-component does not need to call [`updateDropdownLayout`](https://github.com/Addepar/ember-widgets/blob/ebcc0e26b3a1bf92b82dfdb2c51e6432237e239b/addon/components/select-component.js#L165-L205) unless the window size has actually changed. 