### PR TITLE
Add a `isConfirmPrimaryBtn`  flag to modal-component 

### DIFF
--- a/addon/components/modal-component.js
+++ b/addon/components/modal-component.js
@@ -31,6 +31,7 @@ var ModalComponent = Ember.Component.extend(
   cancel: Ember.K,
   close: Ember.K,
   isDisabled: Ember.computed.not('isValid'),
+  isConfirmPrimaryBtn: true,
   fadeEnabled: Ember.computed(function() {
     if (window.EMBER_WIDGETS_DISABLE_ANIMATIONS) {
       return false;

--- a/app/templates/modal-footer.hbs
+++ b/app/templates/modal-footer.hbs
@@ -1,6 +1,6 @@
 {{#if confirmText}}
   <button type="button"
-    class="btn btn-primary btn-confirm {{if isDisabled 'disabled'}}" disabled={{isDisabled}}
+    class="btn {{if isConfirmPrimaryBtn 'btn-primary' 'btn-default'}} btn-confirm {{if isDisabled 'disabled'}}" disabled={{isDisabled}}
     {{action 'sendConfirm'}}>{{confirmText}}
   </button>
 {{/if}}

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
     "jquery-browser": "jquery.browser#~0.0.4",
     "google-code-prettify": "~1.0.4",
     "holder": "holderjs#1.9",
-    "sinonjs": "~1.7.3"
+    "sinonjs": "~1.14.1"
   }
 }

--- a/tests/integration/modal-component-test.js
+++ b/tests/integration/modal-component-test.js
@@ -96,3 +96,26 @@ test('Test pressing Enter to confirm', function(assert) {
     return assert.ok(spy.calledWith('sendConfirm'), "sendConfirm gets called when hitting enter");
   });
 });
+
+test('Test confirm button has default class of btn-primary', function(assert) {
+  var buttonConfirm, modalComponent;
+  assert.expect(2);
+  modal = this.subject();
+  this.render();
+  modalComponent = modal.$();
+  buttonConfirm = find('.btn-confirm', modalComponent);
+  assert.ok(buttonConfirm.hasClass('btn-primary'), 'By default the confirm button has class of btn-primary');
+  assert.ok(!buttonConfirm.hasClass('btn-default'), 'By default the confirm button does not have class of btn-default');
+});
+
+test('Test confirm button can be set to not have default class of btn-primary', function(assert) {
+  var buttonConfirm, modalComponent;
+  assert.expect(2);
+  modal = this.subject();
+  modal.set('isConfirmPrimaryBtn', false);
+  this.render();
+  modalComponent = modal.$();
+  buttonConfirm = find('.btn-confirm', modalComponent);
+  assert.ok(!buttonConfirm.hasClass('btn-primary'), 'When isConfirmPrimaryBtn is set to false the confirm button does not have class of btn-primary');
+  assert.ok(buttonConfirm.hasClass('btn-default'), 'When isConfirmPrimaryBtn is set to false the confirm button  has class of btn-default');
+});


### PR DESCRIPTION
Add a `isConfirmPrimaryBtn` flag to modal-component which determines if the confirm button should be treated as a primary button or not.

By default, value is true and the css class of `btn-primary` gets applied to the confirm button.

When set to false, css class of `btn-default` gets applied instead.