### PR TITLE
Drop Ember 2.0 from CI as it wasn't passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,19 +21,17 @@ env:
   matrix:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
+    # - EMBER_TRY_SCENARIO=ember-2.0
     # - EMBER_TRY_SCENARIO=ember-lts-2.8
     # - EMBER_TRY_SCENARIO=ember-lts-2.12
     # - EMBER_TRY_SCENARIO=ember-release
     # - EMBER_TRY_SCENARIO=ember-beta
     # - EMBER_TRY_SCENARIO=ember-canary
     - EMBER_TRY_SCENARIO=ember-1.13
-    - EMBER_TRY_SCENARIO=ember-2.0
     - EMBER_TRY_SCENARIO=ember-default
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-2.0
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -15,6 +15,7 @@ module.exports = {
         }
       }
     },
+    /*
     {
       name: 'ember-2.0',
       bower: {
@@ -28,7 +29,6 @@ module.exports = {
         }
       }
     },
-    /*
     {
       name: 'ember-lts-2.8',
       bower: {


### PR DESCRIPTION
This permitted-failure on CI was only causing confusion when trying to publish locally. Dropping it completely.