### PR TITLE
Add a component integration test for select-component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - "10"
 
 sudo: true
 dist: trusty

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,9 +1,8 @@
 /* eslint-env node */
 module.exports = {
   browsers: [
-    'ie 9',
-    'last 1 Chrome versions',
-    'last 1 Firefox versions',
-    'last 1 Safari versions'
+    'last 2 Chrome versions',
+    'last 2 Firefox versions',
+    'last 2 Safari versions'
   ]
 };

--- a/tests/integration/components/select-component-test.js
+++ b/tests/integration/components/select-component-test.js
@@ -1,0 +1,105 @@
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent, test } from 'ember-qunit';
+import wait from 'ember-test-helpers/wait';
+import { click } from '@ember/test-helpers';
+
+class SelectPageObject {
+  constructor(elementLookup) {
+    this.$ = elementLookup;
+  }
+
+  get selectResultsElement() {
+    return this.$('.ember-select-results')[0];
+  }
+
+  get selectChoiceElement() {
+    return this.$('.ember-select-choice')[0];
+  }
+
+  selectOptionElementContaining(content) {
+    return this.$(`li:contains(${content}) div`)[0];
+  }
+
+  get selectOptionElements() {
+    return this.$('.ember-select-result-item').toArray();
+  }
+  get selectOptionTextContents() {
+    return this.selectOptionElements.map(e => e.textContent.trim());
+  }
+}
+
+moduleForComponent('select-component', '[Integration] Select component', {
+  integration: true,
+
+  beforeEach() {
+    this.helpers = new SelectPageObject((...args) => this.$(...args));
+  },
+});
+
+test('it renders collapsed, but opens to display options', async function(assert) {
+  this.set('content', [
+    'foo', 'bar', 'bar', 'baz'
+  ]);
+
+  await this.render(hbs`{{select-component content=content}}`);
+
+  assert.ok(
+    !this.helpers.selectResultsElement,
+    'dropdown is not present on initial render'
+  );
+
+  await click(this.helpers.selectChoiceElement);
+
+  assert.ok(
+    this.helpers.selectResultsElement,
+    'dropdown is present after click'
+  );
+});
+
+test('it renders collapsed, but opens to display grouped options', async function(assert) {
+  this.set('content', [
+    {name: 'Sparrow', sound: 'Squawk'},
+    {name: 'Crow', sound: 'Squawk'},
+    {name: 'Dog', sound: 'bark'},
+    {name: 'Wolf', sound: 'Bark'},
+    {name: 'Sea Lion', sound: 'Bark'}
+  ]);
+
+  this.set('collapsedGroupHeaders', Ember.A([
+    'Squawk', 'bark'
+  ]));
+
+  await this.render(hbs`
+  {{select-component
+      content=content
+      optionLabelPath='name'
+      optionValuePath='name'
+      optionGroupPath='sound'
+      isGroupHeaderCollapsible=true
+      collapsedGroupHeaders=collapsedGroupHeaders
+  }}`);
+
+  await click(this.helpers.selectChoiceElement);
+
+  assert.deepEqual(
+    this.helpers.selectOptionTextContents,
+    ['Bark', 'Sea Lion', 'Wolf', 'Squawk', 'bark'],
+    'rendered content includes groups'
+  );
+
+  await click(this.helpers.selectOptionElementContaining('bark'));
+
+  assert.deepEqual(
+    this.helpers.selectOptionTextContents,
+    ['Bark', 'Sea Lion', 'Wolf', 'Squawk', 'bark', 'Dog'],
+    'rendered content includes expanded bark group'
+  );
+
+  await click(this.helpers.selectOptionElementContaining('Bark'));
+
+  assert.deepEqual(
+    this.helpers.selectOptionTextContents,
+    ['Bark', 'Squawk', 'bark', 'Dog'],
+    'rendered content collapses Bark group'
+  );
+});

--- a/tests/integration/select-component-render-test.js
+++ b/tests/integration/select-component-render-test.js
@@ -32,7 +32,7 @@ emptyContentSelector = '.ember-select-empty-content';
 
 noResultSelector = '.ember-select-no-results';
 
-moduleForComponent('select-component', '[Integration] Select component', {
+moduleForComponent('select-component', '[Integration] Select component render', {
   needs: [
     'template:select',
     'template:select-item',
@@ -576,60 +576,5 @@ test('Dropdown does not open on key event when select is disabled', function(ass
 
   andThen(() => {
     assert.ok(isNotPresent('.ember-select-results', selectElement), 'The dropdown does not open');
-  });
-});
-
-test('Collapsed group can be expanded, collapsed', function(assert) {
-  function data() {
-    return [
-      {name: 'Sparrow', sound: 'Squawk'},
-      {name: 'Crow', sound: 'Squawk'},
-      {name: 'Dog', sound: 'bark'},
-      {name: 'Wolf', sound: 'Bark'},
-      {name: 'Sea Lion', sound: 'Bark'}
-    ];
-  }
-  function renderedItems(selectElement) {
-    var resultItems = find('.ember-select-result-item', selectElement);
-    return resultItems.toArray().map(i => i.textContent.trim())
-  }
-
-  select = this.subject({
-    content: data(),
-    optionLabelPath: 'name',
-    optionValuePath: 'name',
-    optionGroupPath: 'sound',
-    isGroupHeaderCollapsible: true,
-    collapsedGroupHeaders: Ember.A(['Squawk', 'bark'])
-  });
-  this.render();
-
-  var selectElement = select.$();
-  openDropdown(selectElement);
-
-  andThen(() => {
-    assert.deepEqual(
-      renderedItems(selectElement),
-      ['Bark', 'Sea Lion', 'Wolf', 'Squawk', 'bark'],
-      'precond - rendered content includes groups'
-    );
-    click('li:contains(bark) div');
-  });
-
-  andThen(() => {
-    assert.deepEqual(
-      renderedItems(selectElement),
-      ['Bark', 'Sea Lion', 'Wolf', 'Squawk', 'bark', 'Dog'],
-      'bark expanded to render Dog'
-    );
-    click('li:contains(Bark) div');
-  });
-
-  andThen(() => {
-    assert.deepEqual(
-      renderedItems(selectElement),
-      ['Bark', 'Squawk', 'bark', 'Dog'],
-      'Bark collapsed, hiding Sea Lion and Wolf'
-    );
   });
 });

--- a/tests/integration/shared/-popover-tests.js
+++ b/tests/integration/shared/-popover-tests.js
@@ -265,12 +265,12 @@ export default function runPopoverTests(test, {makeComponent, openPopover, openM
     );
   });
 
-  test('it closes modals from an event', function(assert) {
+  test('it closes modals from an event', async function(assert) {
     let componentSpec = makeComponent(this, 'test-modal', ModalComponent, {
       layoutName: 'ember-widgets/-test-popover-content',
     });
 
-    this.render(hbs`{{render-popover}}`);
+    await this.render(hbs`{{render-popover}}`);
 
     openModal(this, componentSpec);
 
@@ -279,7 +279,7 @@ export default function runPopoverTests(test, {makeComponent, openPopover, openM
       'The modal is now rendered'
     );
 
-    return new Promise(resolve => {
+    await new Promise(resolve => {
       // The document event handlers are installed in a run.next, so
       // schedule this test/assertion for after that. Additionally,
       // wait for the background fade animation.
@@ -287,15 +287,15 @@ export default function runPopoverTests(test, {makeComponent, openPopover, openM
         $(document).trigger('modal:hide');
         resolve();
       }, 50);
-    }).then(() => {
-      // Wait for an animation
-      return waitUntil(() => document.querySelector('[data-test-popover-content]') === null);
-    }).then(() => {
-      assert.ok(
-        true,
-        'The modal is closed'
-      );
     });
+
+    // Wait for an animation
+    await waitUntil(() => document.querySelector('[data-test-popover-content]') === null);
+
+    assert.ok(
+      true,
+      'The modal is closed'
+    );
   });
 
   test('it closes other modals when opening', function(assert) {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,6 +3,8 @@ import {
   setResolver
 } from '@ember/test-helpers';
 import { start } from 'ember-cli-qunit';
+import { default as registerRAFWaiter } from 'ember-raf-scheduler/test-support/register-waiter';
 
+registerRAFWaiter();
 setResolver(resolver);
 start();


### PR DESCRIPTION
Add two tests actually, one for basic rendering and one for group interaction.

The intent here is to unblock https://github.com/Addepar/ember-widgets/pull/324 from being easily testable.