### PR TITLE
Avoid using globals in the carousel template

### DIFF
--- a/addon/components/carousel-component.js
+++ b/addon/components/carousel-component.js
@@ -16,6 +16,7 @@ export default Ember.Component.extend({
   classNames: ['carousel', 'slide'],
   classNameBindings: Ember.A(['sliding']),
   activeIndex: 0,
+  collectionViewClass: Ember.CollectionView,
   carouselIndicatorClass: CarouselIndicatorView,
   $nextItem: null,
   didInsertElement: function() {

--- a/app/templates/carousel.hbs
+++ b/app/templates/carousel.hbs
@@ -1,4 +1,4 @@
-{{view Ember.CollectionView tagName="ol" class="carousel-indicators"
+{{view collectionViewClass tagName="ol" class="carousel-indicators"
   content=view.content itemViewClass=carouselIndicatorClass
 }}
 <div class="carousel-inner">


### PR DESCRIPTION
This is deprecated. Well, so is CollectionView entirely, but one step at a time :)