### PR TITLE
Bump minimum node version to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - "10"
 
 sudo: true
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "",
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 10.*"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
https://github.com/Addepar/ember-widgets/pull/326 is failing because one of its transitive dependency (globby) now requires Node 10. This PR bumps the minimum node version to address that.