### PR TITLE
Use #each instead of a ContainerView when rendering popovers

### DIFF
--- a/addon/services/popover.js
+++ b/addon/services/popover.js
@@ -131,7 +131,7 @@ export default Ember.Service.extend({
     };
 
     popoverSpec.childViews = [
-      ComponentClass.create({
+      ComponentClass.extend({
         ...options,
         closePopover
       })

--- a/addon/views/popover-container.js
+++ b/addon/views/popover-container.js
@@ -1,3 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.ContainerView.extend({});

--- a/app/templates/components/render-popover.hbs
+++ b/app/templates/components/render-popover.hbs
@@ -4,7 +4,9 @@
     {{#if p.componentName}}
       {{component p.componentName _propertyOptions=p.propertyOptions __renderPopoverNewAPI=true}}
     {{else}}
-      {{view 'popover-container' childViews=p.childViews}}
+      {{#each p.childViews as |childView|}}
+        {{view childView}}
+      {{/each}}
     {{/if}}
   </div>
   {{/ember-wormhole}}

--- a/app/views/popover-container.js
+++ b/app/views/popover-container.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-widgets/views/popover-container';

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -4,7 +4,6 @@ self.deprecationWorkflow.config = {
   workflow: [
     { handler: "silence", matchMessage: "Global lookup of Ember from a Handlebars template is deprecated." },
     { handler: "silence", matchId: "ember-views.dispatching-modify-property" },
-    { handler: "silence", matchMessage: "Setting `childViews` on a Container is deprecated." },
     { handler: "silence", matchMessage: "Using deprecated `template` property on a View." }
   ]
 };


### PR DESCRIPTION
This PR refactors the render-popover component to use an `#each` block rather than a `ContainerView` in order to avoid a `childViews` deprecation.