### PR TITLE
Use ember-object-set-return-value codemod to cleanup set return value usage

### DIFF
--- a/addon/components/carousel-component.js
+++ b/addon/components/carousel-component.js
@@ -25,7 +25,7 @@ export default Ember.Component.extend({
     // figure out how many carousel items are there. This allows us to generate
     // the correct number of carousel indicator
     if (!this.get('content')) {
-      return this.set('content', Ember.A(new Array(this.$('.item').length)));
+      this.set('content', Ember.A(new Array(this.$('.item').length)));
     }
   },
   willDestroyElement: function() {

--- a/addon/components/color-picker-dropdown.js
+++ b/addon/components/color-picker-dropdown.js
@@ -42,9 +42,9 @@ export default Ember.Component.extend(BodyEventListenerMixin, ColorPickerMixin, 
     if (this.get('colorRows').find(function(row) {
       return __indexOf.call(row.invoke('toLowerCase'), selectedColor) >= 0;
     })) {
-      return this.set('customColor', '');
+      this.set('customColor', '');
     }
-    return this.set('customColor', selectedColor);
+    this.set('customColor', selectedColor);
   })),
   /**
    * This is the formatted string of the input color, for which a hashtag "#"

--- a/addon/components/color-picker.js
+++ b/addon/components/color-picker.js
@@ -68,14 +68,14 @@ export default Ember.Component.extend(ColorPickerMixin, {
 
     userSelected: function(selection) {
       this.sendAction('userSelected', selection);
-      return this.set('isDropdownOpen', false);
+      this.set('isDropdownOpen', false);
     },
     /**
      * Hide the color picker dropdown
     */
 
     hideDropdown: function() {
-      return this.set('isDropdownOpen', false);
+      this.set('isDropdownOpen', false);
     },
     /**
      * Set the selected color and update the custom color accordingly
@@ -87,9 +87,9 @@ export default Ember.Component.extend(ColorPickerMixin, {
     setSelectedColor: function(color, isCustomColor) {
       this.set('selectedColor', color);
       if (isCustomColor) {
-        return this.set('customColor', color);
+        this.set('customColor', color);
       } else {
-        return this.set('customColor', '');
+        this.set('customColor', '');
       }
     }
   }

--- a/addon/components/editable-label-component.js
+++ b/addon/components/editable-label-component.js
@@ -20,10 +20,10 @@ export default Ember.Component.extend({
     },
     blur: function() {
       this.set('parentView.isEditing', false);
-      return this.set('parentView.value', this.get('value'));
+      this.set('parentView.value', this.get('value'));
     }
   }),
   editLabel: function() {
-    return this.set('isEditing', true);
+    this.set('isEditing', true);
   }
 });

--- a/addon/components/modal-component.js
+++ b/addon/components/modal-component.js
@@ -154,7 +154,7 @@ var ModalComponent = Ember.Component.extend(
       if (this.isDestroying) {
         return;
       }
-      return this.set('isShowing', true);
+      this.set('isShowing', true);
     });
     // bootstrap modal adds this class to the body when the modal opens to
     // transfer scroll behavior to the modal

--- a/addon/components/multi-select-component.js
+++ b/addon/components/multi-select-component.js
@@ -69,7 +69,7 @@ export default SelectComponent.extend({
       return this.get('selectComponent.placeholder') || this.get('selectComponent.persistentPlaceholder');
     }).property('selectComponent.placeholder', 'selectComponent.persistentPlaceholder', 'selectComponent.selections.length'),
     click: function() {
-      return this.set('selectComponent.showDropdown', true);
+      this.set('selectComponent.showDropdown', true);
     }
   }),
 
@@ -128,7 +128,7 @@ export default SelectComponent.extend({
       this.set('selections', Ember.A([]));
     }
     if (!this.get('values')) {
-      return this.set('values', Ember.A([]));
+      this.set('values', Ember.A([]));
     }
   },
   deletePressed: function(event) {

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -21,9 +21,9 @@ export default Ember.Component.extend({
     var selectedValue;
     selectedValue = this.get('selectedValue');
     if (!Ember.isEmpty(selectedValue) && this.get('value') === selectedValue) {
-      return this.set('checked', true);
+      this.set('checked', true);
     } else {
-      return this.set('checked', false);
+      this.set('checked', false);
     }
   }, 'selectedValue')),
   click: function() {

--- a/addon/components/select-component.js
+++ b/addon/components/select-component.js
@@ -425,7 +425,7 @@ export default Ember.Component.extend(
 
   didInsertElement: function() {
     this._super();
-    return this.setDefaultSelection();
+    this.setDefaultSelection();
   },
 
   // It matches the item label with the query. This can be overrideen for better
@@ -478,7 +478,7 @@ export default Ember.Component.extend(
     if (!(content && defaultPath)) {
       return;
     }
-    return this.set('selection', content.findBy(defaultPath));
+    this.set('selection', content.findBy(defaultPath));
   }),
 
   selectableOptionsDidChange: Ember.observer('selectableOptions.[]', 'showDropdown', function() {
@@ -545,9 +545,9 @@ export default Ember.Component.extend(
     activeElem = document.activeElement;
     selectComponent = this.$()[0];
     if (selectComponent.contains(activeElem) || selectComponent === activeElem) {
-      return this.set('hasFocus', true);
+      this.set('hasFocus', true);
     } else {
-      return this.set('hasFocus', false);
+      this.set('hasFocus', false);
     }
   },
 
@@ -675,11 +675,11 @@ export default Ember.Component.extend(
   },
 
   focusIn: function() {
-    return this.set('hasFocus', true);
+    this.set('hasFocus', true);
   },
 
   focusOut: function() {
-    return this.set('hasFocus', false);
+    this.set('hasFocus', false);
   },
 
   actions: {
@@ -688,7 +688,7 @@ export default Ember.Component.extend(
       if (this.get('disabled')) {
         return;
       }
-      return this.toggleProperty('showDropdown');
+      this.toggleProperty('showDropdown');
     },
 
     toggleGroupHeader: function(groupHeaderName) {
@@ -704,7 +704,7 @@ export default Ember.Component.extend(
       if (this.get('isDestroyed') || this.get('isDestroying')) {
         return;
       }
-      return this.set('showDropdown', false);
+      this.set('showDropdown', false);
     },
 
     valueChanged: function(newText) {

--- a/addon/mixins/popover.js
+++ b/addon/mixins/popover.js
@@ -234,7 +234,7 @@ export default Ember.Mixin.create(StyleBindingsMixin, BodyEventListener, {
       this.set('top', bodyHeight - actualHeight - this.get('marginTop'));
     }
     if (this.get('top') < 0) {
-      return this.set('top', this.get('marginTop'));
+      this.set('top', this.get('marginTop'));
     }
   },
   keyHandler: Ember.computed(function() {

--- a/addon/mixins/tabbable-modal.js
+++ b/addon/mixins/tabbable-modal.js
@@ -33,7 +33,7 @@ export default Ember.Mixin.create(KeyboardHelper, {
         }
       }
       focusElement.focus();
-      return this.set('currentFocus', focusElement);
+      this.set('currentFocus', focusElement);
     }
   },
   _checkContainingElement: function(containers, element) {
@@ -49,7 +49,7 @@ export default Ember.Mixin.create(KeyboardHelper, {
   mouseDown: function(event) {
     this._super(event);
     if (this._checkContainingElement(this.$(':tabbable'), event.target)) {
-      return this.set('currentFocus', event.target);
+      this.set('currentFocus', event.target);
     } else {
       // if we click on a non-tabbable element, we should just set the focus back
       // to the modal and reset the tab loop

--- a/addon/views/select-option.js
+++ b/addon/views/select-option.js
@@ -35,13 +35,6 @@ export default Ember.View.extend({
     return this.labelPathDidChange();
   },
 
-  // TODO(Peter): This is a hack. Some computed don't fire properly if
-  // they are dependent on the context. e.g. isHighlighted may not update
-  // if it is dependent on the context. This seems to fix the issue
-  updateContext: function(context) {
-    this._super(context);
-    return this.set('content', context);
-  },
   click: function() {
     let selection = this.get('content');
     if (get(selection, 'isGroupOption')) {
@@ -61,6 +54,6 @@ export default Ember.View.extend({
     if (this.get('content.isGroupOption')) {
       return;
     }
-    return this.set('highlighted', this.get('content'));
+    this.set('highlighted', this.get('content'));
   }
 });

--- a/tests/integration/color-picker-test.js
+++ b/tests/integration/color-picker-test.js
@@ -46,7 +46,7 @@ moduleForComponent('color-picker', '[Integration] Color picker unit tests', {
 
 testHexConversion = function(assert, colorPicker, color, hex) {
   Ember.run(function() {
-    return colorPicker.set('selectedColor', color);
+    colorPicker.set('selectedColor', color);
   });
   return assert.equal(colorPicker.get('selectedColorRGB'), hex);
 };

--- a/tests/integration/select-component-render-test.js
+++ b/tests/integration/select-component-render-test.js
@@ -507,7 +507,7 @@ test('Selected option is visible when dropdown is opened', function(assert) {
   this.render();
   // The highlighted property is set when the user hovers over the select field
   // Lets programatically set it after rendering to emulate that behavior.
-  andThen(() => select.set('highlighted', selection));
+  andThen(() => { select.set('highlighted', selection); });
   var selectElement = select.$();
   openDropdown(selectElement);
   andThen(() => {
@@ -530,7 +530,7 @@ test('Selected object option is visible when dropdown is opened', function(asser
   var selectElement = select.$();
   // The highlighted property is set when the user hovers over the select field
   // Lets programatically set it after rendering to emulate that behavior.
-  andThen(() => select.set('highlighted', selection));
+  andThen(() => { select.set('highlighted', selection); });
   openDropdown(selectElement);
   andThen(() => {
     assert.ok(isPresent(getOptionSelector(selection.key)), 'The last option is displayed');
@@ -551,7 +551,7 @@ test('Selected option is not visible when shouldEnsureVisible is false', functio
   this.render();
   // The highlighted property is set when the user hovers over the select field
   // Lets programatically set it after rendering to emulate that behavior.
-  andThen(() => select.set('highlighted', selection));
+  andThen(() => { select.set('highlighted', selection); });
   var selectElement = select.$();
   openDropdown(selectElement);
   andThen(() => {


### PR DESCRIPTION
I used an internal codemod [ember-object-set-return-value](https://github.com/Addepar/iverson-codemods/blob/master/transforms/ember-object-set-return-value/README.md) to identify usages of `set`'s return value and then cleaned these cases up manually.

I don't think any of these actually are necessary to remove for upgrading to Ember 2, but it does provide peace of mind.